### PR TITLE
Unify dark mode and merge tenant request list

### DIFF
--- a/src/AnnouncementsPage.js
+++ b/src/AnnouncementsPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTheme } from './ThemeContext';
 import { auth, db } from './firebase';
 import {
   doc,
@@ -20,19 +21,9 @@ export default function AnnouncementsPage() {
   const [form, setForm] = useState({ target: 'all', propertyId: '', tenantUid: '', message: '' });
   const [user, setUser] = useState(null);
   const [firstName, setFirstName] = useState('');
-  const [dark, setDark] = useState(false);
+  const { darkMode } = useTheme();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -113,7 +104,6 @@ export default function AnnouncementsPage() {
             <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments & Billing</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from './ThemeContext';
 import Signup from './Signup';
 import LandlordDashboard from './LandlordDashboard';
 import TenantDashboard from './TenantDashboard';
@@ -16,8 +17,9 @@ import SettingsPage from './SettingsPage';
 
 function App() {
   return (
-    <Router>
-      <Routes>
+    <ThemeProvider>
+      <Router>
+        <Routes>
         <Route path="/" element={<LandingPage/>} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/signin" element={<SignIn />} />
@@ -34,6 +36,7 @@ function App() {
         </Route>
       </Routes>
     </Router>
+    </ThemeProvider>
   );
 }
 

--- a/src/Authentication.js
+++ b/src/Authentication.js
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useTheme } from './ThemeContext';
 import './index.css'; // Assuming you'll move the CSS here or use Tailwind CSS directly
 
 function AuthPage() {
-  const [dark, setDark] = useState(false);
+  const { darkMode, toggleDarkMode } = useTheme();
   const [mode, setMode] = useState('signin'); // 'signin' or 'signup'
   const [form, setForm] = useState({
     role: 'landlord',
@@ -16,14 +17,6 @@ function AuthPage() {
   });
   const [showPass, setShowPass] = useState(false);
 
-  // Effect to apply dark mode class to body
-  useEffect(() => {
-    if (dark) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-  }, [dark]);
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -50,16 +43,16 @@ function AuthPage() {
   };
 
   return (
-    <div className={`antialiased transition-colors duration-500 ${dark ? 'dark' : ''}`}>
+    <div className={`antialiased transition-colors duration-500 ${darkMode ? 'dark' : ''}`}>
       <body className="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 flex flex-col min-h-screen">
         {/* Header */}
         <header className="bg-white dark:bg-gray-800 shadow-md fixed w-full z-10">
           <div className="container mx-auto flex items-center justify-between px-6 py-4">
-            <span className="text-2xl font-bold cursor-pointer" onClick={() => setDark(!dark)}>
+            <span className="text-2xl font-bold cursor-pointer" onClick={toggleDarkMode}>
               EasyLease
             </span>
-            <button onClick={() => setDark(!dark)} aria-label="Toggle dark mode" className="p-2 rounded focus:outline-none">
-              {dark ? (
+            <button onClick={toggleDarkMode} aria-label="Toggle dark mode" className="p-2 rounded focus:outline-none">
+              {darkMode ? (
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-300" fill="currentColor">
                   <path d="M10 2a8 8 0 017.446 4.908A6 6 0 1010 2z" />
                 </svg>

--- a/src/LandingPage.js
+++ b/src/LandingPage.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useTheme } from './ThemeContext';
 import { Link } from 'react-router-dom';
 import './App.css'; // Tailwind CSS should be configured here
 
 function LandingPage() {
   const [mobileMenu, setMobileMenu] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [dark, setDark] = useState(false);
+  const { darkMode, toggleDarkMode } = useTheme();
   const [activeSection, setActiveSection] = useState('home');
 
   // Refs for sections
@@ -36,8 +37,8 @@ function LandingPage() {
 
   // Dark mode toggle
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', dark);
-  }, [dark]);
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
 
   // Testimonials data
   const testimonialsData = [
@@ -51,7 +52,7 @@ function LandingPage() {
       {/* Header */}
       <header className={`fixed w-full z-50 backdrop-blur-lg bg-white dark:bg-gray-900 transition-shadow ${scrolled ? 'shadow-xl' : ''}`}>  
         <div className="container mx-auto flex items-center justify-between px-6 lg:px-8 py-4">
-          <button onClick={() => setDark(!dark)} className="text-2xl font-extrabold focus:outline-none">
+          <button onClick={toggleDarkMode} className="text-2xl font-extrabold focus:outline-none">
             EasyLease
           </button>
           <nav className="hidden md:flex space-x-10 text-lg font-medium">

--- a/src/LandlordDashboard.js
+++ b/src/LandlordDashboard.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTheme } from './ThemeContext';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from './firebase';
 import { doc, getDoc } from 'firebase/firestore';
@@ -18,21 +19,10 @@ export default function LandlordDashboard() {
   const [mobileMenu, setMobileMenu] = useState(false);
   const [user, setUser] = useState(null);
   const [firstName, setFirstName] = useState('');
-  const [dark, setDark] = useState(false);
+  const { darkMode } = useTheme();
   const navigate = useNavigate();
 
   // System theme detection (set once on mount)
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  // Apply dark mode class to root (your preferred logic)
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   // Auth and fetch first name
   useEffect(() => {
@@ -134,7 +124,6 @@ export default function LandlordDashboard() {
             <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments & Billing</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>

--- a/src/MaintenancePage.js
+++ b/src/MaintenancePage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTheme } from './ThemeContext';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from './firebase';
 import {
@@ -19,19 +20,9 @@ export default function MaintenancePage() {
   const [messageMap, setMessageMap] = useState({});
   const [user, setUser] = useState(null);
   const [firstName, setFirstName] = useState('');
-  const [dark, setDark] = useState(false);
+  const { darkMode } = useTheme();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -113,7 +104,6 @@ export default function MaintenancePage() {
             <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments & Billing</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">🛠️ Maintenance</a>

--- a/src/PaymentsPage.js
+++ b/src/PaymentsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTheme } from './ThemeContext';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from './firebase';
 import { doc, getDoc } from 'firebase/firestore';
@@ -6,19 +7,9 @@ import { doc, getDoc } from 'firebase/firestore';
 export default function PaymentsPage() {
   const [firstName, setFirstName] = useState('');
   const [user, setUser] = useState(null);
-  const [dark, setDark] = useState(false);
+  const { darkMode } = useTheme();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -59,7 +50,6 @@ export default function PaymentsPage() {
             <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">💳 Payments & Billing</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>

--- a/src/PropertiesPage.js
+++ b/src/PropertiesPage.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTheme } from './ThemeContext';
 import { auth, db } from './firebase';
 import { doc, getDoc, collection, addDoc, serverTimestamp, getDocs, query, where, deleteDoc } from 'firebase/firestore';
 
@@ -25,24 +26,13 @@ export default function PropertiesPage() {
   const [currentTab, setCurrentTab] = useState('overview');
   const [user, setUser] = useState(null);
   const [firstName, setFirstName] = useState('');
-  const [dark, setDark] = useState(false);
+  const { darkMode } = useTheme();
   const [deleteId, setDeleteId] = useState(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState('');
   const navigate = useNavigate();
 
   // System theme detection (set once on mount)
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  // Apply dark mode class to root
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   // Auth and fetch first name
   useEffect(() => {
@@ -179,7 +169,6 @@ export default function PropertiesPage() {
                       <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments & Billing</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>

--- a/src/SettingsPage.js
+++ b/src/SettingsPage.js
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { auth } from './firebase';
 import { updatePassword } from 'firebase/auth';
+import { useTheme } from './ThemeContext';
 
 export default function SettingsPage() {
   const [tab, setTab] = useState('profile');
@@ -9,7 +10,7 @@ export default function SettingsPage() {
     email: 'john@example.com',
     password: ''
   });
-  const [darkMode, setDarkMode] = useState(false);
+  const { darkMode, toggleDarkMode } = useTheme();
 
   const [notifications, setNotifications] = useState({
     email: true,
@@ -29,16 +30,6 @@ export default function SettingsPage() {
     sms: false
   });
 
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDarkMode(mq.matches);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (darkMode) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [darkMode]);
 
   const saveAll = () => {
     alert('Settings saved');
@@ -164,7 +155,7 @@ export default function SettingsPage() {
                     <span className="text-sm text-gray-700">Dark Mode</span>
                     <button
                       type="button"
-                      onClick={() => setDarkMode(!darkMode)}
+                      onClick={toggleDarkMode}
                       className={`relative inline-flex h-6 w-11 items-center rounded-full ${darkMode ? 'bg-purple-500' : 'bg-gray-300'}`}
                     >
                       <span className="sr-only">Toggle Dark Mode</span>

--- a/src/Signin.js
+++ b/src/Signin.js
@@ -1,24 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { useTheme } from './ThemeContext';
 import { useNavigate } from "react-router-dom";
 import { auth, db } from "./firebase"; // adjust path if needed
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 
 export default function SignIn() {
-  const [dark, setDark] = useState(false);
+  const { darkMode, toggleDarkMode } = useTheme();
   const [error, setError] = useState(null);
   const [showPass, setShowPass] = useState(false);
   const [form, setForm] = useState({ email: '', password: '', remember: false });
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
-  }, [dark]);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -72,11 +65,11 @@ export default function SignIn() {
             EasyLease
           </h1>
           <button
-            onClick={() => setDark(!dark)}
+            onClick={toggleDarkMode}
             aria-label="Toggle theme"
             className="p-2 rounded focus:outline-none"
           >
-            {dark ? (
+            {darkMode ? (
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 className="h-6 w-6 text-yellow-300"

--- a/src/Signup.js
+++ b/src/Signup.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
+import { useTheme } from './ThemeContext';
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { auth, db } from "./firebase";
@@ -6,10 +7,10 @@ import { createUserWithEmailAndPassword } from "firebase/auth";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
 
 export default function SignUp() {
+  const { darkMode, toggleDarkMode } = useTheme();
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
   const navigate = useNavigate();
-  const [dark, setDark] = useState(false);
   const [showPass, setShowPass] = useState(false);
   const [form, setForm] = useState({
     role: 'landlord',
@@ -20,11 +21,6 @@ export default function SignUp() {
     phone: '',
   });
 
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -95,11 +91,11 @@ export default function SignUp() {
             EasyLease
           </h1>
           <button
-            onClick={() => setDark(!dark)}
+            onClick={toggleDarkMode}
             aria-label="Toggle theme"
             className="p-2 rounded focus:outline-none"
           >
-            {dark ? (
+            {darkMode ? (
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-300" fill="currentColor">
                 <path d="M10 2a8 8 0 017.446 4.908A6 6 0 1010 2z" />
               </svg>

--- a/src/TenantRequestsApprovalPage.js
+++ b/src/TenantRequestsApprovalPage.js
@@ -30,19 +30,7 @@ export default function TenantRequestsApprovalPage() {
     endDate: '',
     deposit: '',
   });
-  const [dark, setDark] = useState(false);
   const navigate = useNavigate();
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -163,7 +151,6 @@ export default function TenantRequestsApprovalPage() {
             <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>

--- a/src/TenantsPage.js
+++ b/src/TenantsPage.js
@@ -9,26 +9,29 @@ import {
   query,
   where,
   updateDoc,
-  deleteDoc
+  deleteDoc,
+  addDoc,
+  serverTimestamp
 } from 'firebase/firestore';
 
 export default function TenantsPage() {
   const [tenants, setTenants] = useState([]);
   const [user, setUser] = useState(null);
   const [firstName, setFirstName] = useState('');
-  const [dark, setDark] = useState(false);
+  const [requests, setRequests] = useState([]);
+  const [properties, setProperties] = useState([]);
+  const [selectedRequest, setSelectedRequest] = useState(null);
+  const [selectedPropertyId, setSelectedPropertyId] = useState('');
+  const [showAssignModal, setShowAssignModal] = useState(false);
+  const [assignLoading, setAssignLoading] = useState(false);
+  const [showLeaseModal, setShowLeaseModal] = useState(false);
+  const [leaseDetails, setLeaseDetails] = useState({
+    rent: '',
+    startDate: '',
+    endDate: '',
+    deposit: '',
+  });
   const navigate = useNavigate();
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    setDark(mq.matches);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) root.classList.add('dark');
-    else root.classList.remove('dark');
-  }, [dark]);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -40,6 +43,7 @@ export default function TenantsPage() {
           query(collection(db, 'Properties'), where('landlord_id', '==', u.uid))
         );
         const props = propSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setProperties(props);
         const tenantData = await Promise.all(
           props
             .filter((p) => p.tenant_uid)
@@ -56,6 +60,26 @@ export default function TenantsPage() {
             })
         );
         setTenants(tenantData.filter(Boolean));
+
+        const reqQuery = query(
+          collection(db, 'TenantRequests'),
+          where('landlord_email', '==', u.email),
+          where('status', '==', 'Pending')
+        );
+        const reqSnap = await getDocs(reqQuery);
+        const requestsWithNames = await Promise.all(
+          reqSnap.docs.map(async (d) => {
+            const req = d.data();
+            const userSnap = await getDoc(doc(db, 'Users', req.tenant_uid));
+            return {
+              id: d.id,
+              tenant_uid: req.tenant_uid,
+              tenant_name: userSnap.exists() ? userSnap.data().first_name : 'Unknown',
+              created_at: req.created_at,
+            };
+          })
+        );
+        setRequests(requestsWithNames);
       }
     });
     return () => unsubscribe();
@@ -78,6 +102,47 @@ export default function TenantsPage() {
       setTenants((prev) => prev.filter((t) => t.id !== uid));
     } catch (e) {
       console.error('Failed to delete tenant', e);
+    }
+  };
+
+  const openAssignModal = (req) => {
+    setSelectedRequest(req);
+    setSelectedPropertyId('');
+    setShowAssignModal(true);
+  };
+
+  const handleAssign = async () => {
+    if (!selectedRequest || !selectedPropertyId) return;
+    setAssignLoading(true);
+    try {
+      await updateDoc(doc(db, 'Users', selectedRequest.tenant_uid), { status: 'Active' });
+      await updateDoc(doc(db, 'Properties', selectedPropertyId), { tenant_uid: selectedRequest.tenant_uid });
+      await updateDoc(doc(db, 'TenantRequests', selectedRequest.id), { status: 'Approved' });
+      setRequests((prev) => prev.filter((r) => r.id !== selectedRequest.id));
+      setShowAssignModal(false);
+      setLeaseDetails({ rent: '', startDate: '', endDate: '', deposit: '' });
+      setShowLeaseModal(true);
+    } finally {
+      setAssignLoading(false);
+    }
+  };
+
+  const handleSaveLease = async () => {
+    if (!selectedRequest || !selectedPropertyId) return;
+    try {
+      await addDoc(collection(db, 'Leases'), {
+        tenant_uid: selectedRequest.tenant_uid,
+        property_id: selectedPropertyId,
+        rent_amount: leaseDetails.rent,
+        start_date: leaseDetails.startDate,
+        end_date: leaseDetails.endDate,
+        security_deposit: leaseDetails.deposit,
+        created_at: serverTimestamp(),
+      });
+      setShowLeaseModal(false);
+    } catch (e) {
+      console.error('Failed to save lease', e);
+      alert('Failed to save lease details');
     }
   };
 
@@ -104,7 +169,6 @@ export default function TenantsPage() {
             <a href="/landlord-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏠 Dashboard</a>
             <a href="/properties" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🏢 Properties</a>
             <a href="/tenants" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">👥 Tenants</a>
-            <a href="/approve-requests" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">✅ Approve Requests</a>
             <a href="/announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments & Billing</a>
             <a href="/maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>
@@ -143,8 +207,118 @@ export default function TenantsPage() {
               ))}
             </div>
           )}
+
+          <h2 className="text-2xl font-bold mt-12 mb-6">Pending Tenant Requests</h2>
+          {requests.length === 0 ? (
+            <p className="text-gray-500 dark:text-gray-400">No pending requests at this time.</p>
+          ) : (
+            <ul className="space-y-4">
+              {requests.map((req) => (
+                <li key={req.id} className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow flex items-center justify-between">
+                  <div>
+                    <p className="text-lg font-medium">{req.tenant_name}</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      Requested on: {req.created_at?.seconds ? new Date(req.created_at.seconds * 1000).toLocaleString() : 'N/A'}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => openAssignModal(req)}
+                    className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                  >
+                    Approve
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
+      {showAssignModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md">
+            <h3 className="text-lg font-semibold mb-4 dark:text-gray-100">Assign Property</h3>
+            <select
+              value={selectedPropertyId}
+              onChange={(e) => setSelectedPropertyId(e.target.value)}
+              className="w-full border rounded p-2 mb-4 dark:bg-gray-900 dark:text-gray-100"
+            >
+              <option value="" disabled>
+                Select property
+              </option>
+              {properties.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <div className="flex justify-end space-x-2">
+              <button
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 dark:text-gray-100 rounded"
+                onClick={() => setShowAssignModal(false)}
+                disabled={assignLoading}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+                onClick={handleAssign}
+                disabled={!selectedPropertyId || assignLoading}
+              >
+                {assignLoading ? 'Assigning...' : 'Confirm'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {showLeaseModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md space-y-4">
+            <h3 className="text-lg font-semibold dark:text-gray-100">Lease Details</h3>
+            <input
+              type="number"
+              placeholder="Rent Amount"
+              className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100"
+              value={leaseDetails.rent}
+              onChange={(e) => setLeaseDetails({ ...leaseDetails, rent: e.target.value })}
+            />
+            <input
+              type="text"
+              placeholder="Security Deposit"
+              className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100"
+              value={leaseDetails.deposit}
+              onChange={(e) => setLeaseDetails({ ...leaseDetails, deposit: e.target.value })}
+            />
+            <input
+              type="date"
+              placeholder="Start Date"
+              className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100"
+              value={leaseDetails.startDate}
+              onChange={(e) => setLeaseDetails({ ...leaseDetails, startDate: e.target.value })}
+            />
+            <input
+              type="date"
+              placeholder="End Date"
+              className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100"
+              value={leaseDetails.endDate}
+              onChange={(e) => setLeaseDetails({ ...leaseDetails, endDate: e.target.value })}
+            />
+            <div className="flex justify-end space-x-2">
+              <button
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 dark:text-gray-100 rounded"
+                onClick={() => setShowLeaseModal(false)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                onClick={handleSaveLease}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ThemeContext.js
+++ b/src/ThemeContext.js
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeProvider({ children }) {
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('darkMode');
+    if (stored !== null) {
+      return stored === 'true';
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', darkMode);
+    localStorage.setItem('darkMode', darkMode);
+  }, [darkMode]);
+
+  const value = {
+    darkMode,
+    setDarkMode,
+    toggleDarkMode: () => setDarkMode((prev) => !prev),
+  };
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ThemeContext` for global dark mode
- show pending tenant requests on the tenants page
- remove Approve Request links from sidebars
- wrap the app with `ThemeProvider`
- use context-powered theme toggle in settings and pages

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68813da6bcb48322845e03c5bd66b641