### PR TITLE
Fix timestamp for maintenance updates

### DIFF
--- a/src/MaintenancePage.js
+++ b/src/MaintenancePage.js
@@ -13,7 +13,8 @@ import {
   deleteDoc,
   addDoc,
   serverTimestamp,
-  arrayUnion
+  arrayUnion,
+  Timestamp
 } from 'firebase/firestore';
 
 export default function MaintenancePage() {
@@ -78,17 +79,31 @@ export default function MaintenancePage() {
     const text = updateText.trim();
     if (!text || !activeReq) return;
     await updateDoc(doc(db, 'MaintenanceRequests', activeReq.id), {
-      updates: arrayUnion({ text, by: user.uid, name: firstName, created_at: serverTimestamp() }),
+      updates: arrayUnion({ text, by: user.uid, name: firstName, created_at: Timestamp.now() }),
     });
     setRequests((prev) =>
       prev.map((r) =>
         r.id === activeReq.id
-          ? { ...r, updates: [...(r.updates || []), { text, by: user.uid, name: firstName, created_at: { seconds: Date.now() / 1000 } }] }
+          ? {
+              ...r,
+              updates: [
+                ...(r.updates || []),
+                { text, by: user.uid, name: firstName, created_at: { seconds: Timestamp.now().seconds } },
+              ],
+            }
           : r
       )
     );
     setActiveReq((prev) =>
-      prev ? { ...prev, updates: [...(prev.updates || []), { text, by: user.uid, name: firstName, created_at: { seconds: Date.now() / 1000 } }] } : prev
+      prev
+        ? {
+            ...prev,
+            updates: [
+              ...(prev.updates || []),
+              { text, by: user.uid, name: firstName, created_at: { seconds: Timestamp.now().seconds } },
+            ],
+          }
+        : prev
     );
     setUpdateText('');
   };

--- a/src/TenantMaintenancePage.js
+++ b/src/TenantMaintenancePage.js
@@ -13,6 +13,7 @@ import {
   onSnapshot,
   updateDoc,
   arrayUnion,
+  Timestamp,
 } from 'firebase/firestore';
 
 export default function TenantMaintenancePage() {
@@ -78,7 +79,7 @@ export default function TenantMaintenancePage() {
     const text = updateText.trim();
     if (!text || !activeReq) return;
     await updateDoc(doc(db, 'MaintenanceRequests', activeReq.id), {
-      updates: arrayUnion({ text, by: user.uid, name: firstName, created_at: serverTimestamp() }),
+      updates: arrayUnion({ text, by: user.uid, name: firstName, created_at: Timestamp.now() }),
     });
     setUpdateText('');
   };


### PR DESCRIPTION
## Summary
- store maintenance update timestamps with `Timestamp.now()`
- update local state to reflect the new update object

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6889303c3a548322b71576771cf8b30d