### PR TITLE
fix: ensure jwt token generation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -31,14 +31,18 @@ const db = getFirestore(firebaseApp);
 
 function verifyToken(req, res, next) {
   const authHeader = req.headers['authorization'];
-  if (!authHeader) return res.status(401).json({ message: 'No token provided' });
+  if (!authHeader) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
 
   const token = authHeader.split(' ')[1];
-  jwt.verify(token, SECRET_KEY, (err, decoded) => {
-    if (err) return res.status(401).json({ message: 'Invalid or expired token' });
+  try {
+    const decoded = jwt.verify(token, SECRET_KEY);
     req.user = decoded;
     next();
-  });
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid or expired token' });
+  }
 }
 
 // Authenticate user against Firebase Auth and retrieve role from Firestore
@@ -60,11 +64,20 @@ app.post('/login', async (req, res) => {
 
     const userData = docSnap.data();
 
-    const token = jwt.sign(
-      { email: userData.email || email, role: userData.role, first_name: userData.first_name },
-      SECRET_KEY,
-      { expiresIn: '1h' }
-    );
+    const token = await new Promise((resolve, reject) => {
+      jwt.sign(
+        { email: userData.email || email, role: userData.role, first_name: userData.first_name },
+        SECRET_KEY,
+        { expiresIn: '1h' },
+        (err, generated) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(generated);
+          }
+        }
+      );
+    });
 
     res.json({ token });
   } catch (err) {


### PR DESCRIPTION
## Summary
- replace callback-based JWT verification with synchronous try/catch
- generate tokens using Promise-wrapped jwt.sign to capture async errors

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689283fe84cc832289ce9c36271e3bc7