### PR TITLE
Fix invalid Firestore references in tenant payments

### DIFF
--- a/src/pages/Signup.js
+++ b/src/pages/Signup.js
@@ -71,18 +71,6 @@ export default function SignUp() {
         updated_at: serverTimestamp()
       });
 
-      if (form.role === 'tenant') {
-        await addDoc(collection(db, 'RentPayments'), {
-          tenant_uid: uid,
-          landlord_uid: '',
-          property_id: '',
-          amount: '1000',
-          due_date: new Date().toISOString().split('T')[0],
-          paid: false,
-          created_at: serverTimestamp(),
-        });
-      }
-
       setSuccess(true);
       setTimeout(() => {
         navigate("/signin");

--- a/src/pages/TenantPaymentsPage.js
+++ b/src/pages/TenantPaymentsPage.js
@@ -34,15 +34,16 @@ export default function TenantPaymentsPage() {
         );
         const paySnap = await getDocs(unpaidQuery);
         const unpaid = await Promise.all(
-          paySnap.docs.map(async (d) => {
-            const p = d.data();
-            const propSnap = await getDoc(doc(db, 'Properties', p.property_id));
-            return {
-              id: d.id,
-              propertyName: propSnap.exists() ? propSnap.data().name : '',
-              ...p,
-            };
-          })
+          paySnap.docs
+            .map((d) => ({ id: d.id, ...d.data() }))
+            .filter((p) => p.property_id)
+            .map(async (p) => {
+              const propSnap = await getDoc(doc(db, 'Properties', p.property_id));
+              return {
+                ...p,
+                propertyName: propSnap.exists() ? propSnap.data().name : '',
+              };
+            })
         );
         const paidQuery = query(
           collection(db, 'RentPayments'),
@@ -51,15 +52,16 @@ export default function TenantPaymentsPage() {
         );
         const paidSnap = await getDocs(paidQuery);
         const paid = await Promise.all(
-          paidSnap.docs.map(async (d) => {
-            const p = d.data();
-            const propSnap = await getDoc(doc(db, 'Properties', p.property_id));
-            return {
-              id: d.id,
-              propertyName: propSnap.exists() ? propSnap.data().name : '',
-              ...p,
-            };
-          })
+          paidSnap.docs
+            .map((d) => ({ id: d.id, ...d.data() }))
+            .filter((p) => p.property_id)
+            .map(async (p) => {
+              const propSnap = await getDoc(doc(db, 'Properties', p.property_id));
+              return {
+                ...p,
+                propertyName: propSnap.exists() ? propSnap.data().name : '',
+              };
+            })
         );
         setPayments(unpaid);
         setHistory(paid);


### PR DESCRIPTION
## Summary
- stop creating placeholder RentPayments doc during tenant signup
- skip RentPayments entries without a property ID when loading tenant payments

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68928f5b91988322bdfd3fa62349a655