### PR TITLE
Add unit tests for theme toggle and sign-in password visibility

### DIFF
--- a/src/components/ThemeToggle.test.js
+++ b/src/components/ThemeToggle.test.js
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ThemeToggle from './ThemeToggle';
+import { ThemeProvider } from '../context/ThemeContext';
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.className = '';
+});
+
+test('toggles dark mode on click', async () => {
+  render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+
+  const toggle = screen.getByRole('button', { name: /toggle theme/i });
+  const root = document.documentElement;
+
+  expect(root).not.toHaveClass('dark');
+  await userEvent.click(toggle);
+  expect(root).toHaveClass('dark');
+  expect(localStorage.getItem('darkMode')).toBe('true');
+
+  await userEvent.click(toggle);
+  expect(root).not.toHaveClass('dark');
+  expect(localStorage.getItem('darkMode')).toBe('false');
+});
+

--- a/src/pages/Signin.js
+++ b/src/pages/Signin.js
@@ -75,31 +75,34 @@ export default function SignIn() {
           </h2>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
-              <label className="block text-sm font-medium">Email address</label>
+              <label htmlFor="email" className="block text-sm font-medium">Email address</label>
               <input
-                type="email"
-                name="email"
-                value={form.email}
-                onChange={handleChange}
-                required
-                className="mt-1 block w-full h-12 px-4 border-gray-300 dark:border-gray-700 rounded-lg shadow-sm dark:bg-gray-900 focus:border-indigo-500 focus:ring-indigo-500"
-              />
+                  id="email"
+                  type="email"
+                  name="email"
+                  value={form.email}
+                  onChange={handleChange}
+                  required
+                  className="mt-1 block w-full h-12 px-4 border-gray-300 dark:border-gray-700 rounded-lg shadow-sm dark:bg-gray-900 focus:border-indigo-500 focus:ring-indigo-500"
+                />
             </div>
             <div className="relative">
-              <label className="block text-sm font-medium">Password</label>
+              <label htmlFor="password" className="block text-sm font-medium">Password</label>
               <input
-                type={showPass ? 'text' : 'password'}
-                name="password"
-                value={form.password}
-                onChange={handleChange}
-                required
-                className="mt-1 block w-full h-12 px-4 border-gray-300 dark:border-gray-700 rounded-lg shadow-sm dark:bg-gray-900 pr-10 focus:border-indigo-500 focus:ring-indigo-500"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPass(!showPass)}
-                className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500"
-              >
+                  id="password"
+                  type={showPass ? 'text' : 'password'}
+                  name="password"
+                  value={form.password}
+                  onChange={handleChange}
+                  required
+                  className="mt-1 block w-full h-12 px-4 border-gray-300 dark:border-gray-700 rounded-lg shadow-sm dark:bg-gray-900 pr-10 focus:border-indigo-500 focus:ring-indigo-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPass(!showPass)}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500"
+                  aria-label="Toggle password visibility"
+                >
                 {showPass ? <FaEyeSlash /> : <FaEye />}
               </button>
             </div>

--- a/src/pages/Signin.test.js
+++ b/src/pages/Signin.test.js
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SignIn from './Signin';
+import { ThemeProvider } from '../context/ThemeContext';
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    useNavigate: () => jest.fn(),
+  }),
+  { virtual: true }
+);
+
+jest.mock('../firebase', () => ({ auth: {}, db: {} }), { virtual: true });
+
+function renderSignIn() {
+  return render(
+    <ThemeProvider>
+      <SignIn />
+    </ThemeProvider>
+  );
+}
+
+test('password field toggles visibility', async () => {
+  renderSignIn();
+
+  const passwordField = screen.getByLabelText(/^Password$/i);
+  const toggleButton = screen.getByLabelText(/toggle password visibility/i);
+
+  expect(passwordField).toHaveAttribute('type', 'password');
+  await userEvent.click(toggleButton);
+  expect(passwordField).toHaveAttribute('type', 'text');
+  await userEvent.click(toggleButton);
+  expect(passwordField).toHaveAttribute('type', 'password');
+});
+

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,19 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill matchMedia for components using it (e.g., ThemeProvider)
+window.matchMedia =
+  window.matchMedia ||
+  function (query) {
+    return {
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {}, // deprecated
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() { return false; },
+    };
+  };


### PR DESCRIPTION
## Summary
- add ThemeToggle test verifying dark mode class and localStorage updates
- add SignIn test for password visibility toggle and mock router/firebase
- improve SignIn accessibility with labeled inputs and toggle aria-label
- polyfill matchMedia in test setup

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892be83f1488322aa26e6bbb5da0596