### PR TITLE
feat: upload property photos to firebase storage

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -3,6 +3,7 @@ import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 import { getAuth } from 'firebase/auth'; // Import getAuth for authentication
 import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -22,4 +23,5 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app); // EXPORT THE AUTH OBJECT
 export const db = getFirestore(app);
+export const storage = getStorage(app);
 const analytics = getAnalytics(app);


### PR DESCRIPTION
## Summary
- export Firebase Storage to support file uploads
- upload property images to storage and store their download URLs when adding or editing properties

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689363dab4e88322bd03e302fa245aa8