### PR TITLE
test: add sign-in and private route tests

### DIFF
--- a/src/components/PrivateRoute.test.js
+++ b/src/components/PrivateRoute.test.js
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import PrivateRoute from './PrivateRoute';
+
+let mockCurrentUser;
+jest.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: mockCurrentUser }),
+}));
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Navigate: ({ to }) => <div>Navigate {to}</div>,
+    Outlet: () => <div>Outlet</div>,
+  }),
+  { virtual: true }
+);
+
+describe('PrivateRoute', () => {
+  beforeEach(() => {
+    mockCurrentUser = null;
+  });
+
+  test('renders outlet when user is authenticated', () => {
+    mockCurrentUser = { uid: 'abc' };
+    render(<PrivateRoute />);
+    expect(screen.getByText('Outlet')).toBeInTheDocument();
+  });
+
+  test('redirects to signin when user is not authenticated', () => {
+    mockCurrentUser = null;
+    render(<PrivateRoute />);
+    expect(screen.getByText('Navigate /signin')).toBeInTheDocument();
+  });
+});
+

--- a/src/pages/Signin.test.js
+++ b/src/pages/Signin.test.js
@@ -1,17 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SignIn from './Signin';
 import { ThemeProvider } from '../context/ThemeContext';
 
+const mockNavigate = jest.fn();
 jest.mock(
   'react-router-dom',
   () => ({
-    useNavigate: () => jest.fn(),
+    useNavigate: () => mockNavigate,
   }),
   { virtual: true }
 );
 
+// Mock Firebase utilities
 jest.mock('../firebase', () => ({ auth: {}, db: {} }), { virtual: true });
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { getDoc } from 'firebase/firestore';
+jest.mock('firebase/auth', () => ({ signInWithEmailAndPassword: jest.fn() }));
+jest.mock('firebase/firestore', () => ({ doc: jest.fn(), getDoc: jest.fn() }));
 
 function renderSignIn() {
   return render(
@@ -20,6 +26,11 @@ function renderSignIn() {
     </ThemeProvider>
   );
 }
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.clear();
+});
 
 test('password field toggles visibility', async () => {
   renderSignIn();
@@ -33,4 +44,42 @@ test('password field toggles visibility', async () => {
   await userEvent.click(toggleButton);
   expect(passwordField).toHaveAttribute('type', 'password');
 });
+
+test('landlord sign in navigates to landlord dashboard', async () => {
+  signInWithEmailAndPassword.mockResolvedValue({ user: { uid: '1' } });
+  getDoc.mockResolvedValue({
+    exists: () => true,
+    data: () => ({ role: 'landlord', first_name: 'Larry' }),
+  });
+
+  renderSignIn();
+
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^Password$/i), 'secret');
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+  await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/landlord-dashboard'));
+  expect(signInWithEmailAndPassword).toHaveBeenCalledWith({}, 'a@b.com', 'secret');
+  expect(sessionStorage.getItem('user_email')).toBe('a@b.com');
+  expect(sessionStorage.getItem('user_first_name')).toBe('Larry');
+});
+
+test('tenant sign in navigates to tenant dashboard', async () => {
+  signInWithEmailAndPassword.mockResolvedValue({ user: { uid: '2' } });
+  getDoc.mockResolvedValue({
+    exists: () => true,
+    data: () => ({ role: 'tenant', first_name: 'Tina' }),
+  });
+
+  renderSignIn();
+
+  await userEvent.type(screen.getByLabelText(/email address/i), 't@c.com');
+  await userEvent.type(screen.getByLabelText(/^Password$/i), 'secret');
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+  await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/tenant-dashboard'));
+  expect(sessionStorage.getItem('user_email')).toBe('t@c.com');
+  expect(sessionStorage.getItem('user_first_name')).toBe('Tina');
+});
+
 


### PR DESCRIPTION
## Summary
- expand sign-in tests to cover landlord and tenant navigation flows
- add PrivateRoute tests to validate authenticated routing

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68936abff7ac832292216005d7f82321