### PR TITLE
feat: add maintenance notifications and update navigation

### DIFF
--- a/src/pages/AnalyticsPage.js
+++ b/src/pages/AnalyticsPage.js
@@ -225,20 +225,18 @@ export default function AnalyticsPage() {
           </div>
 
           {expenseChartData && (
-            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow mb-8">
-              <Bar data={expenseChartData} />
+            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow mb-8 h-64">
+              <Bar data={expenseChartData} options={{ maintainAspectRatio: false }} />
             </div>
           )}
           {rentChartData && (
-            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow mb-8">
-              <Line data={rentChartData} />
+            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow mb-8 h-64">
+              <Line data={rentChartData} options={{ maintainAspectRatio: false }} />
             </div>
           )}
           {occupancyChartData && (
-            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow flex justify-center">
-              <div className="w-64 h-64">
-                <Pie data={occupancyChartData} options={{ maintainAspectRatio: false }} />
-              </div>
+            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow flex justify-center h-64">
+              <Pie data={occupancyChartData} options={{ maintainAspectRatio: false }} />
             </div>
           )}
         </div>

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -86,14 +86,18 @@ function LandingPage() {
                   {key.charAt(0).toUpperCase() + key.slice(1)}
                 </a>
               ))}
-              <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-                <button className="w-full text-left py-2 mb-2">Login</button>
-                <button className="w-full text-left py-2">Sign Up</button>
-              </div>
-            </nav>
-          </div>
-        )}
-      </header>
+                <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+                  <Link to="/signin" className="w-full text-left py-2 mb-2" onClick={() => setMobileMenu(false)}>
+                    Login
+                  </Link>
+                  <Link to="/signup" className="w-full text-left py-2" onClick={() => setMobileMenu(false)}>
+                    Sign Up
+                  </Link>
+                </div>
+              </nav>
+            </div>
+          )}
+        </header>
 
       {/* Hero */}
       <section id="home" ref={sections.home} className="pt-32 pb-24 bg-gradient-to-br from-indigo-600 to-purple-600 text-white">
@@ -104,10 +108,10 @@ function LandingPage() {
             </h1>
             <p className="text-lg lg:text-xl text-gray-200 max-w-xl">Powerful dashboard, automated reminders, and seamless integrations to keep your properties running smoothly.</p>
             <div className="flex flex-wrap gap-4 mt-4">
-              <a href="#" className="px-6 py-3 rounded-full bg-white text-indigo-600 font-semibold shadow-lg hover:shadow-xl hover:-translate-y-1 transform transition">Get Started</a>
-              <a href="#" className="inline-flex items-center gap-2 px-4 py-2 border border-white rounded-md hover:bg-white/20 transition text-sm lg:text-base">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16"/></svg>Watch Demo
-              </a>
+                <Link to="/signin" className="px-6 py-3 rounded-full bg-white text-indigo-600 font-semibold shadow-lg hover:shadow-xl hover:-translate-y-1 transform transition">Get Started</Link>
+                <a href="#" className="inline-flex items-center gap-2 px-4 py-2 border border-white rounded-md hover:bg-white/20 transition text-sm lg:text-base">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16"/></svg>Watch Demo
+                </a>
             </div>
           </div>
         </div>
@@ -225,8 +229,8 @@ function LandingPage() {
                 <li>✅ Basic features</li>
                 <li>✅ Email support</li>
               </ul>
-              <button className="px-6 py-3 rounded-full bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition">Get Started</button>
-            </div>
+                <Link to="/signin" className="px-6 py-3 rounded-full bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition">Get Started</Link>
+              </div>
             <div className="p-10 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border-4 border-indigo-600 hover:scale-105 transform transition duration-500">
               <h3 className="text-2xl font-semibold mb-4">Pro Plan</h3>
               <p className="text-5xl font-bold mb-4">$29<span className="text-lg font-normal">/month</span></p>

--- a/src/pages/MaintenancePage.js
+++ b/src/pages/MaintenancePage.js
@@ -124,12 +124,13 @@ export default function MaintenancePage() {
     if (!msg) return;
     const req = requests.find((r) => r.id === id);
     if (!req || !req.tenant_uid) return;
-    await addDoc(collection(db, 'Messages'), {
-      from: user.uid,
-      to: req.tenant_uid,
-      text: msg,
-      created_at: serverTimestamp(),
-    });
+      await addDoc(collection(db, 'Messages'), {
+        from: user.uid,
+        to: req.tenant_uid,
+        text: msg,
+        created_at: serverTimestamp(),
+        read: false,
+      });
     setMessageMap((prev) => ({ ...prev, [id]: '' }));
     alert('Message sent');
   };

--- a/src/pages/TenantMaintenancePage.js
+++ b/src/pages/TenantMaintenancePage.js
@@ -27,6 +27,7 @@ export default function TenantMaintenancePage() {
   const [updateText, setUpdateText] = useState('');
   const [formOpen, setFormOpen] = useState(false);
   const [form, setForm] = useState({ title: '', details: '' });
+  const [unread, setUnread] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -56,6 +57,26 @@ export default function TenantMaintenancePage() {
     });
     return () => unsub();
   }, [user]);
+
+  useEffect(() => {
+    let unsubMessages;
+    const unsubAuth = auth.onAuthStateChanged((u) => {
+      if (unsubMessages) unsubMessages();
+      if (u) {
+        const q = query(collection(db, 'Messages'), where('to', '==', u.uid), where('read', '==', false));
+        unsubMessages = onSnapshot(q, (snap) => {
+          setUnread(snap.size);
+          snap.docs.forEach((d) => updateDoc(doc(db, 'Messages', d.id), { read: true }));
+        });
+      } else {
+        setUnread(0);
+      }
+    });
+    return () => {
+      if (unsubMessages) unsubMessages();
+      unsubAuth();
+    };
+  }, []);
 
   const handleLogout = async () => {
     await auth.signOut();
@@ -109,7 +130,7 @@ export default function TenantMaintenancePage() {
           <nav className="px-4 space-y-2 mt-4">
             <a href="/tenant-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">📄 Lease Info</a>
             <a href="/tenant-payments" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">💳 Payments</a>
-            <a href="/tenant-maintenance" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">🛠️ Maintenance</a>
+              <a href="/tenant-maintenance" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">🛠️ Maintenance{unread > 0 && <span className="ml-2 bg-red-500 text-white rounded-full text-xs px-2">{unread}</span>}</a>
             <a href="/tenant-announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/tenant-settings" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👤 Profile &amp; Settings</a>
           </nav>

--- a/src/pages/TenantPaymentsPage.js
+++ b/src/pages/TenantPaymentsPage.js
@@ -10,6 +10,7 @@ import {
   getDoc,
   updateDoc,
   serverTimestamp,
+  onSnapshot,
 } from 'firebase/firestore';
 
 export default function TenantPaymentsPage() {
@@ -20,6 +21,7 @@ export default function TenantPaymentsPage() {
   const [user, setUser] = useState(null);
   const [activePayment, setActivePayment] = useState(null);
   const [ccInfo, setCcInfo] = useState({ number: '', expiry: '', cvc: '' });
+  const [unread, setUnread] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -87,6 +89,23 @@ export default function TenantPaymentsPage() {
     return () => unsubscribe();
   }, []);
 
+  useEffect(() => {
+    let unsubMessages;
+    const unsubAuth = auth.onAuthStateChanged((u) => {
+      if (unsubMessages) unsubMessages();
+      if (u) {
+        const q = query(collection(db, 'Messages'), where('to', '==', u.uid), where('read', '==', false));
+        unsubMessages = onSnapshot(q, (snap) => setUnread(snap.size));
+      } else {
+        setUnread(0);
+      }
+    });
+    return () => {
+      if (unsubMessages) unsubMessages();
+      unsubAuth();
+    };
+  }, []);
+
   const handleLogout = async () => {
     await auth.signOut();
     navigate('/signin');
@@ -125,7 +144,7 @@ export default function TenantPaymentsPage() {
           <nav className="px-4 space-y-2 mt-4">
             <a href="/tenant-dashboard" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">📄 Lease Info</a>
             <a href="/tenant-payments" className="flex items-center px-4 py-3 rounded-lg bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200">💳 Payments</a>
-            <a href="/tenant-maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance</a>
+              <a href="/tenant-maintenance" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🛠️ Maintenance{unread > 0 && <span className="ml-2 bg-red-500 text-white rounded-full text-xs px-2">{unread}</span>}</a>
             <a href="/tenant-announcements" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">🔔 Announcements</a>
             <a href="/tenant-settings" className="flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">👤 Profile &amp; Settings</a>
           </nav>


### PR DESCRIPTION
## Summary
- resize analytics charts for consistent display
- open lease documents in new tab and add maintenance message badges
- link landing page calls-to-action and mobile auth buttons to login

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6893bbd5ba188322a0c3c7671dbd61e5