### PR TITLE
Use correct Firebase Storage bucket

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,7 +13,8 @@ const firebaseConfig = {
   apiKey: "AIzaSyDH-9HMnMIMnpP7JT3HwODG1cZRrFTr-Ko",
   authDomain: "easylease-sgaap.firebaseapp.com",
   projectId: "easylease-sgaap",
-  storageBucket: "easylease-sgaap.appspot.com",
+  // Updated to match the correct Firebase Storage bucket
+  storageBucket: "easylease-sgaap.firebasestorage.app",
   messagingSenderId: "1097212604433",
   appId: "1:1097212604433:web:b9179f3228068f5d3a01b0",
   measurementId: "G-0HXJV0VGHS"
@@ -23,5 +24,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app); // EXPORT THE AUTH OBJECT
 export const db = getFirestore(app);
-export const storage = getStorage(app);
+// Use the specified storage bucket for all storage operations
+export const storage = getStorage(app, "gs://easylease-sgaap.firebasestorage.app");
 const analytics = getAnalytics(app);


### PR DESCRIPTION
## Summary
- fix Firebase config to point at gs://easylease-sgaap.firebasestorage.app
- ensure `getStorage` uses the specified bucket

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68988b63daf88322a5165ccbe2fc9d9f