### PR TITLE
Store signed leases in storage and enforce tenant capacity

### DIFF
--- a/src/pages/PropertiesPage.js
+++ b/src/pages/PropertiesPage.js
@@ -653,7 +653,7 @@ export default function PropertiesPage() {
                     .join(', ') || <span className="italic text-gray-400 dark:text-gray-500">No address</span>}
                 </p>
                 <p className="dark:text-gray-200">
-                  <strong>Units:</strong> {currentProp.units || 0}
+                  <strong>Units:</strong> {currentProp.units || 4}
                 </p>
                 <p className="dark:text-gray-200">
                   <strong>Tenants:</strong> {currentProp.tenants ? currentProp.tenants.length : currentProp.tenant_uid ? 1 : 0}
@@ -665,10 +665,10 @@ export default function PropertiesPage() {
                   <p className="dark:text-gray-200 whitespace-pre-line">{currentProp.description}</p>
                 )}
                 {propertyLeases.map((l) => (
-                  l.signed_agreement ? (
+                  l.signed_agreement_url ? (
                     <p key={l.id} className="dark:text-gray-200">
                       <a
-                        href={l.signed_agreement}
+                        href={l.signed_agreement_url}
                         download={`signed_agreement_${l.id}.pdf`}
                         className="text-blue-600 underline"
                       >

--- a/src/pages/TenantRequestsApprovalPage.js
+++ b/src/pages/TenantRequestsApprovalPage.js
@@ -217,11 +217,14 @@ export default function TenantRequestsApprovalPage() {
               <option value="" disabled>
                 Select property
               </option>
-              {properties.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.address_line1 || p.name}
-                </option>
-              ))}
+              {properties.map((p) => {
+                const full = (p.tenants || []).length >= 4;
+                return (
+                  <option key={p.id} value={p.id} disabled={full}>
+                    {p.address_line1 || p.name}{full ? ' (Full)' : ''}
+                  </option>
+                );
+              })}
             </select>
             <div className="flex justify-end space-x-2">
               <button

--- a/src/pages/TenantsPage.js
+++ b/src/pages/TenantsPage.js
@@ -310,11 +310,14 @@ export default function TenantsPage() {
               <option value="" disabled>
                 Select property
               </option>
-              {properties.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.address_line1 || p.name}
-                </option>
-              ))}
+              {properties.map((p) => {
+                const full = (p.tenants || []).length >= 4;
+                return (
+                  <option key={p.id} value={p.id} disabled={full}>
+                    {p.address_line1 || p.name}{full ? ' (Full)' : ''}
+                  </option>
+                );
+              })}
             </select>
             <div className="flex justify-end space-x-2">
               <button


### PR DESCRIPTION
## Summary
- Upload tenant-signed lease PDFs to Firebase Storage and store their download URLs
- Show default of four units on property detail view
- Disable assigning more than four tenants to a property

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68992c8307ec8322a90fe47d1a950646