### PR TITLE
Standardize mobile nav across landlord and tenant pages

### DIFF
--- a/src/constants/navItems.js
+++ b/src/constants/navItems.js
@@ -1,0 +1,22 @@
+export function landlordNavItems({ active, pendingTenants = 0, newRequests = 0 } = {}) {
+  return [
+    { icon: '🏠', label: 'Dashboard', href: '/landlord-dashboard', active: active === 'dashboard' },
+    { icon: '🏢', label: 'Properties', href: '/properties', active: active === 'properties' },
+    { icon: '👥', label: 'Tenants', href: '/tenants', active: active === 'tenants', badge: pendingTenants },
+    { icon: '🔔', label: 'Announcements', href: '/announcements', active: active === 'announcements' },
+    { icon: '💳', label: 'Payments', href: '/payments', active: active === 'payments' },
+    { icon: '🛠️', label: 'Maintenance', href: '/maintenance', active: active === 'maintenance', badge: newRequests },
+    { icon: '📊', label: 'Analytics', href: '/analytics', active: active === 'analytics' },
+    { icon: '⚙️', label: 'Settings', href: '/settings', active: active === 'settings' },
+  ];
+}
+
+export function tenantNavItems({ active, unread = 0 } = {}) {
+  return [
+    { icon: '📄', label: 'Lease Info', href: '/tenant-dashboard', active: active === 'dashboard' },
+    { icon: '💳', label: 'Payments', href: '/tenant-payments', active: active === 'payments' },
+    { icon: '🛠️', label: 'Maintenance', href: '/tenant-maintenance', active: active === 'maintenance', badge: unread },
+    { icon: '🔔', label: 'Announcements', href: '/tenant-announcements', active: active === 'announcements' },
+    { icon: '👤', label: 'Profile & Settings', href: '/tenant-settings', active: active === 'settings' },
+  ];
+}

--- a/src/pages/AnalyticsPage.js
+++ b/src/pages/AnalyticsPage.js
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
 import { auth, db } from '../firebase';
 import { collection, getDocs, query, where, doc, getDoc } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 import { Line, Bar, Pie } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -46,6 +48,8 @@ export default function AnalyticsPage() {
     await auth.signOut();
     navigate('/signin');
   };
+
+  const navItems = landlordNavItems({ active: 'analytics' });
 
   useEffect(() => {
     const unsub = auth.onAuthStateChanged(async (u) => {
@@ -188,6 +192,7 @@ export default function AnalyticsPage() {
               Logout
             </button>
           </div>
+          <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/AnnouncementsPage.js
+++ b/src/pages/AnnouncementsPage.js
@@ -13,6 +13,8 @@ import {
   deleteDoc,
   serverTimestamp
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 export default function AnnouncementsPage() {
   const [announcements, setAnnouncements] = useState([]);
@@ -24,6 +26,13 @@ export default function AnnouncementsPage() {
   const [filterProp, setFilterProp] = useState('');
   const { darkMode } = useTheme();
   const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await auth.signOut();
+    navigate('/signin');
+  };
+
+  const navItems = landlordNavItems({ active: 'announcements' });
 
   const tenantMap = tenants.reduce((acc, t) => ({ ...acc, [t.id]: t.name }), {});
 
@@ -91,11 +100,12 @@ export default function AnnouncementsPage() {
             {firstName && <span className="font-medium text-white dark:text-gray-100">{firstName}</span>}
             <button
               className="px-6 py-2 rounded-full bg-gradient-to-r from-indigo-600 to-purple-700 text-white hover:scale-105 transform transition dark:from-gray-700 dark:to-gray-900"
-              onClick={async () => { await auth.signOut(); navigate('/signin'); }}
+              onClick={handleLogout}
             >
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/LandlordDashboard.js
+++ b/src/pages/LandlordDashboard.js
@@ -3,6 +3,7 @@ import { useTheme } from '../context/ThemeContext';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from '../firebase';
 import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 import {
   doc,
   getDoc,
@@ -192,16 +193,7 @@ export default function LandlordDashboard() {
     Completed: 'text-green-500 dark:text-green-400',
   };
 
-  const navItems = [
-    { icon: '🏠', label: 'Dashboard', href: '/landlord-dashboard', active: true },
-    { icon: '🏢', label: 'Properties', href: '/properties' },
-    { icon: '👥', label: 'Tenants', href: '/tenants', badge: pendingTenants },
-    { icon: '🔔', label: 'Announcements', href: '/announcements' },
-    { icon: '💳', label: 'Payments', href: '/payments' },
-    { icon: '🛠️', label: 'Maintenance', href: '/maintenance', badge: newRequests },
-    { icon: '📊', label: 'Analytics', href: '/analytics' },
-    { icon: '⚙️', label: 'Settings', href: '/settings' },
-  ];
+  const navItems = landlordNavItems({ active: 'dashboard', pendingTenants, newRequests });
 
   return (
     <div className="min-h-screen flex flex-col antialiased text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100">

--- a/src/pages/MaintenancePage.js
+++ b/src/pages/MaintenancePage.js
@@ -16,6 +16,8 @@ import {
   arrayUnion,
   Timestamp
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 export default function MaintenancePage() {
   const [requests, setRequests] = useState([]);
@@ -73,6 +75,8 @@ export default function MaintenancePage() {
     await auth.signOut();
     navigate('/signin');
   };
+
+  const navItems = landlordNavItems({ active: 'maintenance' });
 
   const updateStatus = async (id, status, exp) => {
     const data = { status };
@@ -178,6 +182,7 @@ export default function MaintenancePage() {
               Logout
             </button>
           </div>
+          <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/PaymentsPage.js
+++ b/src/pages/PaymentsPage.js
@@ -13,6 +13,8 @@ import {
   serverTimestamp,
   addDoc,
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 export default function PaymentsPage() {
   const [firstName, setFirstName] = useState('');
@@ -86,6 +88,8 @@ export default function PaymentsPage() {
     navigate('/signin');
   };
 
+  const navItems = landlordNavItems({ active: 'payments' });
+
   const markPaid = async (id) => {
     await updateDoc(doc(db, 'RentPayments', id), {
       paid: true,
@@ -124,6 +128,7 @@ export default function PaymentsPage() {
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/PropertiesPage.js
+++ b/src/pages/PropertiesPage.js
@@ -5,6 +5,7 @@ import { auth, db, storage } from '../firebase';
 import { doc, getDoc, collection, setDoc, serverTimestamp, getDocs, query, where, deleteDoc, updateDoc } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 const PROVINCES = [
   'Alberta',
@@ -104,16 +105,7 @@ export default function PropertiesPage() {
     navigate('/signin');
   };
 
-  const navItems = [
-    { icon: '🏠', label: 'Dashboard', href: '/landlord-dashboard' },
-    { icon: '🏢', label: 'Properties', href: '/properties', active: true },
-    { icon: '👥', label: 'Tenants', href: '/tenants' },
-    { icon: '🔔', label: 'Announcements', href: '/announcements' },
-    { icon: '💳', label: 'Payments', href: '/payments' },
-    { icon: '🛠️', label: 'Maintenance', href: '/maintenance' },
-    { icon: '📊', label: 'Analytics', href: '/analytics' },
-    { icon: '⚙️', label: 'Settings', href: '/settings' },
-  ];
+  const navItems = landlordNavItems({ active: 'properties' });
 
   const openDetail = async (prop) => {
     setCurrentProp(prop);

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -4,6 +4,7 @@ import { updatePassword } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
 import { useTheme } from '../context/ThemeContext';
 import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 export default function SettingsPage() {
   const [tab, setTab] = useState('profile');
@@ -89,16 +90,7 @@ export default function SettingsPage() {
     await auth.signOut();
   };
 
-  const navItems = [
-    { icon: '🏠', label: 'Dashboard', href: '/landlord-dashboard' },
-    { icon: '🏢', label: 'Properties', href: '/properties' },
-    { icon: '👥', label: 'Tenants', href: '/tenants' },
-    { icon: '🔔', label: 'Announcements', href: '/announcements' },
-    { icon: '💳', label: 'Payments', href: '/payments' },
-    { icon: '🛠️', label: 'Maintenance', href: '/maintenance' },
-    { icon: '📊', label: 'Analytics', href: '/analytics' },
-    { icon: '⚙️', label: 'Settings', href: '/settings', active: true },
-  ];
+  const navItems = landlordNavItems({ active: 'settings' });
 
   return (
     <div className="min-h-screen antialiased bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 flex flex-col">

--- a/src/pages/TenantAnnouncementsPage.js
+++ b/src/pages/TenantAnnouncementsPage.js
@@ -22,6 +22,8 @@ export default function TenantAnnouncementsPage() {
   const [unread, setUnread] = useState(0);
   const navigate = useNavigate();
 
+  const navItems = tenantNavItems({ active: 'announcements', unread });
+
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
       setUser(u);
@@ -103,6 +105,7 @@ export default function TenantAnnouncementsPage() {
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/TenantDashboard.js
+++ b/src/pages/TenantDashboard.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { auth, db, storage } from '../firebase';
+import MobileNav from '../components/MobileNav';
+import { tenantNavItems } from '../constants/navItems';
 import { doc, getDoc, updateDoc, collection, addDoc, serverTimestamp, getDocs, query, where, onSnapshot } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 
@@ -12,8 +14,6 @@ export default function TenantDashboard() {
   const [landlordEmail, setLandlordEmail] = useState('');
   const [requestSent, setRequestSent] = useState(false);
   const [sendingRequest, setSendingRequest] = useState(false);
-  const [mobileMenu, setMobileMenu] = useState(false);
-
   const [property, setProperty] = useState(null);
   const [lease, setLease] = useState(null);
   const [uploadMessage, setUploadMessage] = useState('');
@@ -22,13 +22,7 @@ export default function TenantDashboard() {
   const userFirstName = sessionStorage.getItem('user_first_name');
   const userEmail = sessionStorage.getItem('user_email');
 
-  const navItems = [
-    { icon: '📄', label: 'Lease Info', href: '/tenant-dashboard', active: true },
-    { icon: '💳', label: 'Payments', href: '/tenant-payments' },
-    { icon: '🛠️', label: 'Maintenance', href: '/tenant-maintenance', badge: unread },
-    { icon: '🔔', label: 'Announcements', href: '/tenant-announcements' },
-    { icon: '👤', label: 'Profile & Settings', href: '/tenant-settings' },
-  ];
+  const navItems = tenantNavItems({ active: 'dashboard', unread });
 
   useEffect(() => {
     const fetchUserStatus = async () => {
@@ -177,43 +171,9 @@ export default function TenantDashboard() {
               Logout
             </button>
           </div>
-          <button className="md:hidden" onClick={() => setMobileMenu(!mobileMenu)}>
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </button>
-        </div>
-        {mobileMenu && (
-          <div className="absolute top-full left-0 w-full bg-white dark:bg-gray-800 shadow-md md:hidden">
-            <nav className="px-4 py-2 space-y-2">
-              {navItems.map((item) => (
-                <a
-                  key={item.label}
-                  href={item.href}
-                  className={`flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                    item.active ? 'bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200' : ''
-                  } relative`}
-                  onClick={() => setMobileMenu(false)}
-                >
-                  <span className="text-xl mr-3">{item.icon}</span>
-                  {item.label}
-                  {item.badge > 0 && (
-                    <span className="absolute right-4 top-1/2 -translate-y-1/2 bg-red-600 text-white text-xs rounded-full px-2">
-                      {item.badge}
-                    </span>
-                  )}
-                </a>
-              ))}
-              <button
-                onClick={handleLogout}
-                className="w-full text-left px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
-                🚪 Logout
-              </button>
-            </nav>
-          </div>
-        )}
-      </header>
+          <MobileNav navItems={navItems} handleLogout={handleLogout} />
+      </div>
+    </header>
   );
 
   if (status === 'Inactive') {

--- a/src/pages/TenantMaintenancePage.js
+++ b/src/pages/TenantMaintenancePage.js
@@ -15,6 +15,8 @@ import {
   arrayUnion,
   Timestamp,
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { tenantNavItems } from '../constants/navItems';
 
 export default function TenantMaintenancePage() {
   const [requests, setRequests] = useState([]);
@@ -29,6 +31,8 @@ export default function TenantMaintenancePage() {
   const [form, setForm] = useState({ title: '', details: '' });
   const [unread, setUnread] = useState(0);
   const navigate = useNavigate();
+
+  const navItems = tenantNavItems({ active: 'maintenance', unread });
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -122,6 +126,7 @@ export default function TenantMaintenancePage() {
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/TenantPaymentsPage.js
+++ b/src/pages/TenantPaymentsPage.js
@@ -12,6 +12,8 @@ import {
   serverTimestamp,
   onSnapshot,
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { tenantNavItems } from '../constants/navItems';
 
 export default function TenantPaymentsPage() {
   const [payments, setPayments] = useState([]);
@@ -23,6 +25,8 @@ export default function TenantPaymentsPage() {
   const [ccInfo, setCcInfo] = useState({ number: '', expiry: '', cvc: '' });
   const [unread, setUnread] = useState(0);
   const navigate = useNavigate();
+
+  const navItems = tenantNavItems({ active: 'payments', unread });
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (u) => {
@@ -136,6 +140,7 @@ export default function TenantPaymentsPage() {
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/TenantRequestsApprovalPage.js
+++ b/src/pages/TenantRequestsApprovalPage.js
@@ -14,6 +14,8 @@ import {
   serverTimestamp,
   arrayUnion,
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 export default function TenantRequestsApprovalPage() {
   const [requests, setRequests] = useState([]);
@@ -140,6 +142,8 @@ export default function TenantRequestsApprovalPage() {
     navigate('/signin');
   };
 
+  const navItems = landlordNavItems({ active: 'tenants', pendingTenants: requests.length });
+
   return (
     <div className="min-h-screen flex flex-col antialiased text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100">
       {/* Header */}
@@ -160,6 +164,7 @@ export default function TenantRequestsApprovalPage() {
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 

--- a/src/pages/TenantSettingsPage.js
+++ b/src/pages/TenantSettingsPage.js
@@ -4,6 +4,7 @@ import { updatePassword } from 'firebase/auth';
 import { doc, getDoc, collection, query, where, onSnapshot } from 'firebase/firestore';
 import { useTheme } from '../context/ThemeContext';
 import MobileNav from '../components/MobileNav';
+import { tenantNavItems } from '../constants/navItems';
 
 export default function TenantSettingsPage() {
   const [tab, setTab] = useState('profile');
@@ -107,13 +108,7 @@ export default function TenantSettingsPage() {
     await auth.signOut();
   };
 
-  const navItems = [
-    { icon: '📄', label: 'Lease Info', href: '/tenant-dashboard' },
-    { icon: '💳', label: 'Payments', href: '/tenant-payments' },
-    { icon: '🛠️', label: 'Maintenance', href: '/tenant-maintenance', badge: unread },
-    { icon: '🔔', label: 'Announcements', href: '/tenant-announcements' },
-    { icon: '👤', label: 'Profile & Settings', href: '/tenant-settings', active: true },
-  ];
+  const navItems = tenantNavItems({ active: 'settings', unread });
 
   return (
     <div className="min-h-screen antialiased bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 flex flex-col">

--- a/src/pages/TenantsPage.js
+++ b/src/pages/TenantsPage.js
@@ -15,6 +15,8 @@ import {
   arrayUnion,
   arrayRemove,
 } from 'firebase/firestore';
+import MobileNav from '../components/MobileNav';
+import { landlordNavItems } from '../constants/navItems';
 
 export default function TenantsPage() {
   const [tenants, setTenants] = useState([]);
@@ -89,6 +91,8 @@ export default function TenantsPage() {
     await auth.signOut();
     navigate('/signin');
   };
+
+  const navItems = landlordNavItems({ active: 'tenants', pendingTenants: requests.length });
 
   const handleDelete = async (uid) => {
     if (!window.confirm('Delete tenant?')) return;
@@ -195,6 +199,7 @@ export default function TenantsPage() {
               Logout
             </button>
           </div>
+            <MobileNav navItems={navItems} handleLogout={handleLogout} />
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- add shared `landlordNavItems` and `tenantNavItems` helpers
- wire MobileNav into all landlord and tenant pages for consistent navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f1a3b6548322922f0a2b9a1e7cd0