### PR TITLE
Fix tenant imports and improve login validation

### DIFF
--- a/src/pages/Signin.js
+++ b/src/pages/Signin.js
@@ -7,52 +7,60 @@ import { signInWithEmailAndPassword } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 
 export default function SignIn() {
-  const [error, setError] = useState(null);
+  const [errors, setErrors] = useState({});
   const [showPass, setShowPass] = useState(false);
   const [form, setForm] = useState({ email: '', password: '', remember: false });
   const navigate = useNavigate();
 
-
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setForm(prev => ({
+    setForm((prev) => ({
       ...prev,
-      [name]: type === 'checkbox' ? checked : value
+      [name]: type === 'checkbox' ? checked : value,
     }));
+    setErrors((prev) => ({ ...prev, [name]: '' }));
   };
 
   const handleSubmit = async (e) => {
-      e.preventDefault();
-      setError(null);
-  
-      try {
-        // 1) Authenticate with Firebase Auth
-        const { user } = await signInWithEmailAndPassword(
-          auth,
-          form.email,
-          form.password
-        );
-  
-        // 2) Fetch user document from Firestore
-        const snap = await getDoc(doc(db, "Users", user.uid));
-        if (!snap.exists()) throw new Error("Profile not found.");
-  
-        const { role, first_name } = snap.data();
-  
-        // 3) Store session variables
-        sessionStorage.setItem("user_email", form.email);
-        sessionStorage.setItem("user_first_name", first_name);
-  
-        // 4) Redirect based on role
-        if (role === "landlord") {
-          navigate("/landlord-dashboard");
-        } else {
-          navigate("/tenant-dashboard");
-        }
-      } catch (e) {
-        setError(e.message);
+    e.preventDefault();
+    const newErrors = {};
+
+    if (!form.email) newErrors.email = 'Email is required';
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) newErrors.email = 'Invalid email address';
+    if (!form.password) newErrors.password = 'Password is required';
+
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors);
+      return;
+    }
+
+    try {
+      // 1) Authenticate with Firebase Auth
+      const { user } = await signInWithEmailAndPassword(auth, form.email, form.password);
+
+      // 2) Fetch user document from Firestore
+      const snap = await getDoc(doc(db, "Users", user.uid));
+      if (!snap.exists()) throw new Error("Profile not found.");
+
+      const { role, first_name } = snap.data();
+
+      // 3) Store session variables
+      sessionStorage.setItem("user_email", form.email);
+      sessionStorage.setItem("user_first_name", first_name);
+
+      // 4) Redirect based on role
+      if (role === "landlord") {
+        navigate("/landlord-dashboard");
+      } else {
+        navigate("/tenant-dashboard");
       }
-    };
+    } catch (e) {
+      if (e.code === 'auth/invalid-email') setErrors({ email: 'Invalid email address' });
+      else if (e.code === 'auth/user-not-found') setErrors({ email: 'Email not found' });
+      else if (e.code === 'auth/wrong-password') setErrors({ password: 'Incorrect password' });
+      else setErrors({ general: e.message });
+    }
+  };
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
@@ -73,38 +81,51 @@ export default function SignIn() {
           <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-6">
             Sign In
           </h2>
+          {errors.general && <p className="text-sm text-red-600 mb-4">{errors.general}</p>}
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <label htmlFor="email" className="block text-sm font-medium">Email address</label>
               <input
-                  id="email"
-                  type="email"
-                  name="email"
-                  value={form.email}
-                  onChange={handleChange}
-                  required
-                  className="mt-1 block w-full h-12 px-4 border-gray-300 dark:border-gray-700 rounded-lg shadow-sm dark:bg-gray-900 focus:border-indigo-500 focus:ring-indigo-500"
-                />
+                id="email"
+                type="email"
+                name="email"
+                value={form.email}
+                onChange={handleChange}
+                required
+                aria-invalid={Boolean(errors.email)}
+                className={`mt-1 block w-full h-12 px-4 rounded-lg shadow-sm dark:bg-gray-900 focus:ring-1 focus:outline-none ${
+                  errors.email
+                    ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+                    : 'border-gray-300 dark:border-gray-700 focus:border-indigo-500 focus:ring-indigo-500'
+                }`}
+              />
+              {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
             </div>
             <div className="relative">
               <label htmlFor="password" className="block text-sm font-medium">Password</label>
               <input
-                  id="password"
-                  type={showPass ? 'text' : 'password'}
-                  name="password"
-                  value={form.password}
-                  onChange={handleChange}
-                  required
-                  className="mt-1 block w-full h-12 px-4 border-gray-300 dark:border-gray-700 rounded-lg shadow-sm dark:bg-gray-900 pr-10 focus:border-indigo-500 focus:ring-indigo-500"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPass(!showPass)}
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500"
-                  aria-label="Toggle password visibility"
-                >
+                id="password"
+                type={showPass ? 'text' : 'password'}
+                name="password"
+                value={form.password}
+                onChange={handleChange}
+                required
+                aria-invalid={Boolean(errors.password)}
+                className={`mt-1 block w-full h-12 px-4 rounded-lg shadow-sm dark:bg-gray-900 pr-10 focus:ring-1 focus:outline-none ${
+                  errors.password
+                    ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+                    : 'border-gray-300 dark:border-gray-700 focus:border-indigo-500 focus:ring-indigo-500'
+                }`}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPass(!showPass)}
+                className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500"
+                aria-label="Toggle password visibility"
+              >
                 {showPass ? <FaEyeSlash /> : <FaEye />}
               </button>
+              {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password}</p>}
             </div>
             <div className="flex justify-between items-center">
               <label className="inline-flex items-center">

--- a/src/pages/Signin.test.js
+++ b/src/pages/Signin.test.js
@@ -82,4 +82,27 @@ test('tenant sign in navigates to tenant dashboard', async () => {
   expect(sessionStorage.getItem('user_first_name')).toBe('Tina');
 });
 
+test('shows error for invalid email format', async () => {
+  renderSignIn();
+
+  await userEvent.type(screen.getByLabelText(/email address/i), 'invalid');
+  await userEvent.type(screen.getByLabelText(/^Password$/i), 'secret');
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+  expect(await screen.findByText(/invalid email address/i)).toBeInTheDocument();
+  expect(signInWithEmailAndPassword).not.toHaveBeenCalled();
+});
+
+test('shows error when password is incorrect', async () => {
+  signInWithEmailAndPassword.mockRejectedValue({ code: 'auth/wrong-password' });
+
+  renderSignIn();
+
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^Password$/i), 'wrong');
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+  expect(await screen.findByText(/incorrect password/i)).toBeInTheDocument();
+});
+
 

--- a/src/pages/TenantAnnouncementsPage.js
+++ b/src/pages/TenantAnnouncementsPage.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from '../firebase';
+import MobileNav from '../components/MobileNav';
+import { tenantNavItems } from '../constants/navItems';
 import {
   collection,
   query,


### PR DESCRIPTION
## Summary
- fix missing imports on tenant announcements page
- add field-level validation to sign-in form and display errors
- test sign-in validations and wrong credentials

## Testing
- `CI=true npm test --silent -- --runTestsByPath src/pages/Signin.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899f79a41308322b0c3b0f4554e916d