### PR TITLE
fix: remove self dependency causing workflow failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "chart.js": "^4.5.0",
-        "easy-lease": "file:",
         "firebase": "^11.9.1",
         "framer-motion": "^12.19.2",
         "react": "^19.1.0",
@@ -7588,10 +7587,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/easy-lease": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "chart.js": "^4.5.0",
-    "easy-lease": "file:",
     "firebase": "^11.9.1",
     "framer-motion": "^12.19.2",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- remove `easy-lease` self reference from package dependencies so npm can install in CI

## Testing
- `npm test -- --watchAll=false`
- `npm ci`


------
https://chatgpt.com/codex/tasks/task_e_6899fb08470883229caf007005bcd46d