### PR TITLE
Animate mobile sidebars and improve readability

### DIFF
--- a/src/components/MobileNav.js
+++ b/src/components/MobileNav.js
@@ -21,8 +21,12 @@ export default function MobileNav({ navItems = [], handleLogout }) {
   };
 
   return (
-    <div className="md:hidden relative">
-      <button onClick={() => setOpen(!open)} className="p-2">
+    <div className="md:hidden">
+      <button
+        onClick={() => setOpen(true)}
+        className="p-2"
+        aria-label="Open menu"
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-6 w-6"
@@ -30,37 +34,78 @@ export default function MobileNav({ navItems = [], handleLogout }) {
           viewBox="0 0 24 24"
           stroke="currentColor"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 6h16M4 12h16M4 18h16"
+          />
         </svg>
       </button>
-      {open && (
-        <div className="absolute top-full left-0 w-screen bg-white dark:bg-gray-800 shadow-md z-20">
-          <nav className="px-4 py-2 space-y-2">
-            {navItems.map((item) => (
-              <a
-                key={item.label}
-                href={item.href}
-                onClick={() => setOpen(false)}
-                className={`flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 ${item.active ? 'bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200' : ''}`}
-              >
-                <span className="text-xl mr-3">{item.icon}</span>
-                {item.label}
-                {item.badge > 0 && (
-                  <span className="ml-auto bg-red-600 text-white text-xs rounded-full px-2">
-                    {item.badge}
-                  </span>
-                )}
-              </a>
-            ))}
-            <button
-              onClick={logout}
-              className="w-full flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+      {/* Overlay */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity ${
+          open ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        onClick={() => setOpen(false)}
+      />
+      {/* Sidebar */}
+      <nav
+        className={`fixed top-0 left-0 z-50 h-full w-64 bg-white dark:bg-gray-800 shadow-xl transform transition-transform duration-300 ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="px-4 py-4 border-b dark:border-gray-700 flex items-center justify-between">
+          <span className="text-lg font-semibold">Menu</span>
+          <button
+            onClick={() => setOpen(false)}
+            className="p-2"
+            aria-label="Close menu"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
             >
-              <span className="text-xl mr-3">🚪</span>Logout
-            </button>
-          </nav>
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
         </div>
-      )}
+        <div className="px-4 py-4 space-y-2 text-lg">
+          {navItems.map((item) => (
+            <a
+              key={item.label}
+              href={item.href}
+              onClick={() => setOpen(false)}
+              className={`flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                item.active
+                  ? 'bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200'
+                  : ''
+              }`}
+            >
+              <span className="text-xl mr-3">{item.icon}</span>
+              <span>{item.label}</span>
+              {item.badge > 0 && (
+                <span className="ml-auto bg-red-600 text-white text-xs rounded-full px-2">
+                  {item.badge}
+                </span>
+              )}
+            </a>
+          ))}
+          <button
+            onClick={logout}
+            className="w-full flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            <span className="text-xl mr-3">🚪</span>
+            <span>Logout</span>
+          </button>
+        </div>
+      </nav>
     </div>
   );
 }

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -72,32 +72,62 @@ function LandingPage() {
               Sign Up
             </Link>
           </div>
-          <button onClick={() => setMobileMenu(!mobileMenu)} className="md:hidden p-2 focus:outline-none">
+          <button
+            onClick={() => setMobileMenu(true)}
+            className="md:hidden p-2 focus:outline-none"
+            aria-label="Open menu"
+          >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
             </svg>
           </button>
         </div>
-        {mobileMenu && (
-          <div className="md:hidden bg-white dark:bg-gray-900 shadow-lg">
-            <nav className="flex flex-col p-6 space-y-3 text-base">
-              {Object.keys(sections).map(key => (
-                <a key={key} href={`#${key}`} className="py-2" onClick={() => setMobileMenu(false)}>
-                  {key.charAt(0).toUpperCase() + key.slice(1)}
-                </a>
-              ))}
-                <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-                  <Link to="/signin" className="block w-full text-left py-2 mb-2" onClick={() => setMobileMenu(false)}>
-                    Login
-                  </Link>
-                  <Link to="/signup" className="block w-full text-left py-2" onClick={() => setMobileMenu(false)}>
-                    Sign Up
-                  </Link>
-                </div>
-              </nav>
+        {/* Overlay */}
+        <div
+          className={`fixed inset-0 z-40 bg-black/50 transition-opacity md:hidden ${
+            mobileMenu ? 'opacity-100' : 'pointer-events-none opacity-0'
+          }`}
+          onClick={() => setMobileMenu(false)}
+        />
+        {/* Sidebar */}
+        <nav
+          className={`fixed top-0 left-0 z-50 h-full w-64 bg-white dark:bg-gray-900 shadow-xl transform transition-transform duration-300 md:hidden ${
+            mobileMenu ? 'translate-x-0' : '-translate-x-full'
+          }`}
+        >
+          <div className="px-6 py-4 border-b dark:border-gray-700 flex items-center justify-between">
+            <span className="text-lg font-semibold">Menu</span>
+            <button
+              onClick={() => setMobileMenu(false)}
+              className="p-2"
+              aria-label="Close menu"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
+          <div className="flex flex-col p-6 space-y-3 text-lg">
+            {Object.keys(sections).map(key => (
+              <a key={key} href={`#${key}`} className="py-2" onClick={() => setMobileMenu(false)}>
+                {key.charAt(0).toUpperCase() + key.slice(1)}
+              </a>
+            ))}
+            <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+              <Link to="/signin" className="block w-full text-left py-2 mb-2" onClick={() => setMobileMenu(false)}>
+                Login
+              </Link>
+              <Link to="/signup" className="block w-full text-left py-2" onClick={() => setMobileMenu(false)}>
+                Sign Up
+              </Link>
             </div>
-          )}
-        </header>
+          </div>
+        </nav>
+      </header>
 
       {/* Hero */}
       <section id="home" ref={sections.home} className="pt-32 pb-24 bg-gradient-to-br from-indigo-600 to-purple-600 text-white">


### PR DESCRIPTION
## Summary
- Replace dropdown mobile nav with animated sliding sidebar and overlay
- Ensure menu items include readable text labels
- Apply dramatic slide animation and close controls on landing page mobile menu

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a4945a7ac832297f8887e301a4726