### PR TITLE
Fix dark mode input visibility and mobile sidebar background

### DIFF
--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -91,7 +91,7 @@ function LandingPage() {
         />
         {/* Sidebar */}
         <nav
-          className={`fixed top-0 left-0 z-50 h-full w-64 bg-white dark:bg-gray-900 shadow-xl transform transition-transform duration-300 md:hidden ${
+          className={`fixed top-0 left-0 z-50 h-full w-64 bg-gradient-to-b from-indigo-600 to-purple-700 text-white dark:bg-gray-900 dark:text-gray-100 shadow-xl transform transition-transform duration-300 md:hidden ${
             mobileMenu ? 'translate-x-0' : '-translate-x-full'
           }`}
         >

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -160,7 +160,7 @@ export default function SettingsPage() {
                       type="text"
                       value={profile.name}
                       onChange={e => setProfile({ ...profile, name: e.target.value })}
-                      className="mt-1 block w-full border-gray-300 rounded-lg shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                      className="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-purple-500 focus:ring-purple-500 bg-white text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                     />
                   </div>
                   <div>
@@ -169,7 +169,7 @@ export default function SettingsPage() {
                       type="email"
                       value={profile.email}
                       onChange={e => setProfile({ ...profile, email: e.target.value })}
-                      className="mt-1 block w-full border-gray-300 rounded-lg shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                      className="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-purple-500 focus:ring-purple-500 bg-white text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                     />
                   </div>
                   <div>
@@ -179,7 +179,7 @@ export default function SettingsPage() {
                       value={profile.password}
                       onChange={e => setProfile({ ...profile, password: e.target.value })}
                       placeholder="••••••••"
-                      className="mt-1 block w-full border-gray-300 rounded-lg shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                      className="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-purple-500 focus:ring-purple-500 bg-white text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                     />
                     <button
                       type="button"

--- a/src/pages/TenantSettingsPage.js
+++ b/src/pages/TenantSettingsPage.js
@@ -175,7 +175,7 @@ export default function TenantSettingsPage() {
                       type="text"
                       value={profile.name}
                       onChange={e => setProfile({ ...profile, name: e.target.value })}
-                      className="mt-1 block w-full border-gray-300 rounded-lg shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                      className="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-purple-500 focus:ring-purple-500 bg-white text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                     />
                   </div>
                   <div>
@@ -184,7 +184,7 @@ export default function TenantSettingsPage() {
                       type="email"
                       value={profile.email}
                       onChange={e => setProfile({ ...profile, email: e.target.value })}
-                      className="mt-1 block w-full border-gray-300 rounded-lg shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                      className="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-purple-500 focus:ring-purple-500 bg-white text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                     />
                   </div>
                   <div>
@@ -194,7 +194,7 @@ export default function TenantSettingsPage() {
                       value={profile.password}
                       onChange={e => setProfile({ ...profile, password: e.target.value })}
                       placeholder="••••••••"
-                      className="mt-1 block w-full border-gray-300 rounded-lg shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                      className="mt-1 block w-full rounded-lg shadow-sm border-gray-300 focus:border-purple-500 focus:ring-purple-500 bg-white text-gray-900 placeholder-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                     />
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- Ensure settings form inputs are readable in dark mode
- Give landing page mobile sidebar a solid theme-colored background

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a9355e4248322bac616137925562f