### PR TITLE
feat: address autocomplete and dashboard metric cleanup

### DIFF
--- a/src/components/AddressAutocomplete.js
+++ b/src/components/AddressAutocomplete.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from 'react';
+
+export default function AddressAutocomplete({ value, onChange, onSelect }) {
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    let autocomplete;
+    const initAutocomplete = () => {
+      if (!window.google || !window.google.maps || !inputRef.current) return;
+      autocomplete = new window.google.maps.places.Autocomplete(inputRef.current, {
+        types: ['address'],
+      });
+      autocomplete.addListener('place_changed', () => {
+        const place = autocomplete.getPlace();
+        if (!place.address_components) return;
+        const get = (type) => {
+          const comp = place.address_components.find((c) => c.types.includes(type));
+          return comp ? comp.long_name : '';
+        };
+        const line1 = [get('street_number'), get('route')].filter(Boolean).join(' ');
+        const city = get('locality');
+        const province = get('administrative_area_level_1');
+        const zip = get('postal_code');
+        onSelect({
+          address_line1: line1,
+          city,
+          province,
+          zip_code: zip,
+        });
+      });
+    };
+
+    if (!window.google || !window.google.maps) {
+      const existing = document.getElementById('google-maps-script');
+      if (!existing) {
+        const script = document.createElement('script');
+        script.id = 'google-maps-script';
+        script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}&libraries=places`;
+        script.async = true;
+        script.onload = initAutocomplete;
+        document.body.appendChild(script);
+      } else {
+        existing.addEventListener('load', initAutocomplete);
+      }
+    } else {
+      initAutocomplete();
+    }
+
+    return () => {
+      if (autocomplete) {
+        window.google.maps.event.clearInstanceListeners(autocomplete);
+      }
+    };
+  }, [onSelect]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100 dark:border-gray-700"
+    />
+  );
+}

--- a/src/pages/AnalyticsPage.js
+++ b/src/pages/AnalyticsPage.js
@@ -36,7 +36,6 @@ export default function AnalyticsPage() {
   const [firstName, setFirstName] = useState('');
   const [metrics, setMetrics] = useState({
     properties: 0,
-    occupied: 0,
     tenants: 0,
     pendingRequests: 0,
     rentRate: 0,
@@ -63,13 +62,11 @@ export default function AnalyticsPage() {
         query(collection(db, 'Properties'), where('landlord_id', '==', u.uid))
       );
       const props = propSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-      let occupied = 0;
       const tenantSet = new Set();
       const occupancyLabels = [];
       const occupancyValues = [];
       props.forEach((data) => {
         const t = data.tenants || [];
-        occupied += t.length;
         t.forEach((id) => tenantSet.add(id));
         occupancyLabels.push(data.name);
         occupancyValues.push(t.length);
@@ -167,7 +164,6 @@ export default function AnalyticsPage() {
 
       setMetrics({
         properties,
-        occupied,
         tenants,
         pendingRequests,
         rentRate: Number(rentRate.toFixed(1)),
@@ -221,9 +217,8 @@ export default function AnalyticsPage() {
 
         <div className="flex-1 p-6 overflow-y-auto">
           <h2 className="text-2xl font-bold mb-8">Analytics</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
             <MetricCard title="Properties" value={metrics.properties} />
-            <MetricCard title="Occupied Units" value={metrics.occupied} />
             <MetricCard title="Active Tenants" value={metrics.tenants} />
             <MetricCard title="Pending Requests" value={metrics.pendingRequests} />
             <MetricCard title="Rent Collection Rate" value={`${metrics.rentRate}%`} />

--- a/src/pages/PropertiesPage.js
+++ b/src/pages/PropertiesPage.js
@@ -6,6 +6,7 @@ import { doc, getDoc, collection, setDoc, serverTimestamp, getDocs, query, where
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import MobileNav from '../components/MobileNav';
 import { landlordNavItems } from '../constants/navItems';
+import AddressAutocomplete from '../components/AddressAutocomplete';
 
 const PROVINCES = [
   'Alberta',
@@ -427,12 +428,14 @@ export default function PropertiesPage() {
                 </div>
                 <div>
                   <label className="block text-sm font-medium dark:text-gray-300">Address Line 1*</label>
-                  <input
-                    type="text"
+                  <AddressAutocomplete
                     value={newProperty.address_line1}
-                    onChange={e => setNewProperty({ ...newProperty, address_line1: e.target.value })}
-                    className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100 dark:border-gray-700"
-                    required
+                    onChange={(val) =>
+                      setNewProperty({ ...newProperty, address_line1: val })
+                    }
+                    onSelect={(addr) =>
+                      setNewProperty((prev) => ({ ...prev, ...addr }))
+                    }
                   />
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- add Google Places-based address autocomplete when adding properties
- remove "Occupied Units" metric and evenly layout remaining analytics cards

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ba021d554832296a6b141ea1d7f02