### PR TITLE
Enable address autocomplete for property edits

### DIFF
--- a/src/pages/PropertiesPage.js
+++ b/src/pages/PropertiesPage.js
@@ -553,12 +553,12 @@ export default function PropertiesPage() {
                 </div>
                 <div>
                   <label className="block text-sm font-medium dark:text-gray-300">Address Line 1*</label>
-                  <input
-                    type="text"
+                  <AddressAutocomplete
                     value={editProperty.address_line1}
-                    onChange={(e) => setEditProperty({ ...editProperty, address_line1: e.target.value })}
-                    className="w-full border rounded p-2 dark:bg-gray-900 dark:text-gray-100 dark:border-gray-700"
-                    required
+                    onChange={(val) => setEditProperty({ ...editProperty, address_line1: val })}
+                    onSelect={(addr) =>
+                      setEditProperty((prev) => ({ ...prev, ...addr }))
+                    }
                   />
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- Use AddressAutocomplete in property edit form to provide suggestions
- Selecting an address now auto-fills city, province, and zip code

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bac7676ec83229e78265d7b055c3d