### PR TITLE
fix: ensure address components returned in autocomplete

### DIFF
--- a/src/components/AddressAutocomplete.js
+++ b/src/components/AddressAutocomplete.js
@@ -7,8 +7,14 @@ export default function AddressAutocomplete({ value, onChange, onSelect }) {
     let autocomplete;
     const initAutocomplete = () => {
       if (!window.google || !window.google.maps || !inputRef.current) return;
+      // Google Places Autocomplete requires explicitly specifying the fields
+      // you want returned when using `getPlace`. Without this, `place.address_components`
+      // will be undefined in recent versions of the API, which breaks our logic
+      // for extracting the street/city/province information.
       autocomplete = new window.google.maps.places.Autocomplete(inputRef.current, {
         types: ['address'],
+        // Request the address components so we can parse the selected place.
+        fields: ['address_components'],
       });
       autocomplete.addListener('place_changed', () => {
         const place = autocomplete.getPlace();

--- a/src/components/AddressAutocomplete.test.js
+++ b/src/components/AddressAutocomplete.test.js
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import AddressAutocomplete from './AddressAutocomplete';
+
+afterEach(() => {
+  delete global.window.google;
+});
+
+test('initializes Google Autocomplete with address fields', () => {
+  const addListener = jest.fn();
+  const AutocompleteMock = jest.fn(() => ({ addListener }));
+  const clearInstanceListeners = jest.fn();
+  global.window.google = {
+    maps: {
+      places: { Autocomplete: AutocompleteMock },
+      event: { clearInstanceListeners },
+    },
+  };
+
+  render(
+    <AddressAutocomplete value="" onChange={() => {}} onSelect={() => {}} />
+  );
+
+  expect(AutocompleteMock).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({
+      types: ['address'],
+      fields: ['address_components'],
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- request address components from Google Places Autocomplete to fix address suggestion
- add unit test to verify the fields are requested

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689bb08fd9208322a4ec1e194270de10