### PR TITLE
Enable Firebase Cloud Messaging across app

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,6 +3,24 @@ const admin = require('firebase-admin');
 
 admin.initializeApp();
 
+const db = admin.firestore();
+
+async function sendNotificationToUsers(userIds, title, body) {
+  const uniqueIds = Array.from(new Set(userIds.filter(Boolean)));
+  if (uniqueIds.length === 0) return;
+  const snaps = await Promise.all(
+    uniqueIds.map((uid) => db.collection('Users').doc(uid).get())
+  );
+  const tokens = snaps
+    .map((s) => s.exists && s.data().fcmToken)
+    .filter((t) => !!t);
+  if (tokens.length === 0) return;
+  await admin.messaging().sendEachForMulticast({
+    tokens,
+    notification: { title, body },
+  });
+}
+
 exports.sendMonthlyRentReminders = functions.pubsub
   .schedule('0 9 1 * *')
   .timeZone('UTC')
@@ -40,4 +58,37 @@ exports.sendMonthlyRentReminders = functions.pubsub
 
     await batch.commit();
     console.log(`Processed ${paymentsSnap.size} payments`);
+  });
+
+exports.notifyRentPaymentChange = functions.firestore
+  .document('RentPayments/{paymentId}')
+  .onWrite(async (change) => {
+    const data = change.after.exists ? change.after.data() : change.before.data();
+    await sendNotificationToUsers(
+      [data.tenant_uid, data.landlord_uid],
+      'Rent Payment Updated',
+      'A rent payment record has changed.'
+    );
+  });
+
+exports.notifyMaintenanceRequestChange = functions.firestore
+  .document('MaintenanceRequests/{requestId}')
+  .onWrite(async (change) => {
+    const data = change.after.exists ? change.after.data() : change.before.data();
+    await sendNotificationToUsers(
+      [data.tenant_uid, data.landlord_id],
+      'Maintenance Request Updated',
+      data.title || 'A maintenance request has changed.'
+    );
+  });
+
+exports.notifyMessageCreated = functions.firestore
+  .document('Messages/{messageId}')
+  .onCreate(async (snap) => {
+    const data = snap.data();
+    await sendNotificationToUsers(
+      [data.to],
+      'New Message',
+      data.text || 'You have a new message.'
+    );
   });

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,24 @@
+importScripts('https://www.gstatic.com/firebasejs/11.9.1/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/11.9.1/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: "AIzaSyDH-9HMnMIMnpP7JT3HwODG1cZRrFTr-Ko",
+  authDomain: "easylease-sgaap.firebaseapp.com",
+  projectId: "easylease-sgaap",
+  storageBucket: "easylease-sgaap.firebasestorage.app",
+  messagingSenderId: "1097212604433",
+  appId: "1:1097212604433:web:b9179f3228068f5d3a01b0",
+  measurementId: "G-0HXJV0VGHS"
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(function(payload) {
+  const notificationTitle = payload.notification?.title || 'EasyLease';
+  const notificationOptions = {
+    body: payload.notification?.body,
+    icon: '/logo192.png'
+  };
+
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -4,6 +4,7 @@ import { getAnalytics } from "firebase/analytics";
 import { getAuth } from 'firebase/auth'; // Import getAuth for authentication
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
+import { getMessaging } from 'firebase/messaging';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -26,4 +27,5 @@ export const auth = getAuth(app); // EXPORT THE AUTH OBJECT
 export const db = getFirestore(app);
 // Use the specified storage bucket for all storage operations
 export const storage = getStorage(app, "gs://easylease-sgaap.firebasestorage.app");
+export const messaging = getMessaging(app);
 const analytics = getAnalytics(app);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import './index.css';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
+import { auth, db, messaging } from './firebase';
+import { doc, setDoc } from 'firebase/firestore';
+import { getToken } from 'firebase/messaging';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -13,3 +16,23 @@ root.render(
 );
 
 serviceWorkerRegistration.register();
+
+auth.onAuthStateChanged(async (user) => {
+  if (!user || !('Notification' in window)) return;
+  try {
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return;
+
+    const registration = await navigator.serviceWorker.ready;
+    const token = await getToken(messaging, {
+      vapidKey: process.env.REACT_APP_VAPID_KEY,
+      serviceWorkerRegistration: registration,
+    });
+
+    if (token) {
+      await setDoc(doc(db, 'Users', user.uid), { fcmToken: token }, { merge: true });
+    }
+  } catch (err) {
+    console.error('Unable to get permission to notify or save token', err);
+  }
+});


### PR DESCRIPTION
## Summary
- initialize Firebase Cloud Messaging and export messaging instance
- register a messaging service worker and save user tokens after notification permission
- send FCM alerts from Cloud Functions when payments, maintenance requests, or messages change

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689c2bb01b8c8322aa4db49439badd71