### PR TITLE
Use EasyLease branding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" id="favicon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>EasyLease</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,20 @@ import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import { auth, db, messaging } from './firebase';
 import { doc, setDoc } from 'firebase/firestore';
 import { getToken } from 'firebase/messaging';
+import easyLeaseLogo from './EasyLease Logo.png';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <AuthProvider>
     <App />
-  </AuthProvider>
+  </AuthProvider>,
 );
+
+document.title = 'EasyLease';
+const favicon = document.getElementById('favicon');
+if (favicon) {
+  favicon.href = easyLeaseLogo;
+}
 
 serviceWorkerRegistration.register();
 


### PR DESCRIPTION
## Summary
- show EasyLease logo as favicon
- set page title to EasyLease

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689cf0985a248322be916e59260feb37