### PR TITLE
feat: add HelloSign signing for tenants

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,5 +39,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script src="https://cdn.hellosign.com/public/js/embedded/v2.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate HelloSign embedded signing for unsigned leases
- load HelloSign client script globally and hardcode API key

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0f2fe3688322ab1cd0f53f63dbcf