### PR TITLE
feat: hardcode HelloSign credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# HelloSign credentials are hardcoded in src/pages/TenantDashboard.js
+# Replace them there if needed
+
+# Existing variable
+REACT_APP_VAPID_KEY=your_firebase_vapid_key

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The Google Maps Places API is required for address autocomplete. For now, the ke
 
 In production, consider storing this key in an environment variable. An `.env.example` file is provided as a template for that setup.
 
+### HelloSign
+
+Embedded lease signing uses HelloSign. The API key and client ID are currently hardcoded in `src/pages/TenantDashboard.js`. Update the `HELLOSIGN_API_KEY` and `HELLOSIGN_CLIENT_ID` constants in that file with your own credentials when deploying.
+
 ## Available Scripts
 
 In the project directory, you can run:


### PR DESCRIPTION
## Summary
- hardcode HelloSign API key and client ID for embedded signing
- document credential placement and remove related env vars

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d141ca5748322983bc90b550c007e