### PR TITLE
fix: include client ID when opening HelloSign

### DIFF
--- a/src/pages/TenantDashboard.js
+++ b/src/pages/TenantDashboard.js
@@ -158,7 +158,7 @@ export default function TenantDashboard() {
 
       const openHelloSign = () => {
         if (window && window.HelloSign && window.HelloSign.open) {
-          window.HelloSign.open({ url: signUrl });
+          window.HelloSign.open({ url: signUrl, clientId: HELLOSIGN_CLIENT_ID });
           window.HelloSign.on('sign', async () => {
             try {
               const fileResp = await fetch(`https://api.hellosign.com/v3/signature_request/files/${signatureRequestId}?file_type=pdf`, {


### PR DESCRIPTION
## Summary
- ensure HelloSign.open includes clientId to avoid missing parameter error

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d1f7d8dd08322949cdec54d1fdc63