### PR TITLE
Fetch signed lease via cloud function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ const admin = require('firebase-admin');
 admin.initializeApp();
 
 const db = admin.firestore();
+const HELLOSIGN_API_KEY = 'f91934661f9c4374956ba03c3d2997ad15835e9e250f68ddccbe903dd1ec3344';
 
 async function sendNotificationToUsers(userIds, title, body) {
   const uniqueIds = Array.from(new Set(userIds.filter(Boolean)));
@@ -92,3 +93,43 @@ exports.notifyMessageCreated = functions.firestore
       data.text || 'You have a new message.'
     );
   });
+
+exports.fetchSignedPdf = functions.https.onRequest(async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Content-Type');
+  res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  const { signatureRequestId } = req.body || {};
+  if (!signatureRequestId) {
+    res.status(400).json({ error: 'signatureRequestId is required' });
+    return;
+  }
+
+  try {
+    const resp = await fetch(
+      `https://api.hellosign.com/v3/signature_request/files/${signatureRequestId}?file_type=pdf`,
+      {
+        headers: {
+          Authorization:
+            'Basic ' + Buffer.from(HELLOSIGN_API_KEY + ':').toString('base64'),
+        },
+      }
+    );
+    if (!resp.ok) {
+      const txt = await resp.text();
+      console.error('HelloSign fetch failed', txt);
+      res.status(500).json({ error: 'Unable to fetch signed PDF' });
+      return;
+    }
+    const arrayBuffer = await resp.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString('base64');
+    res.json({ base64 });
+  } catch (err) {
+    console.error('Error fetching signed PDF', err);
+    res.status(500).json({ error: 'Unable to fetch signed PDF' });
+  }
+});


### PR DESCRIPTION
## Summary
- convert `fetchSignedPdf` to an HTTP Cloud Function with explicit CORS headers
- update tenant dashboard to call the function via `fetch` and store the signed PDF
- remove unused Firebase Functions client setup

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d4332e0e88322a56cddc9454da7ec