### PR TITLE
Display full name in settings pages

### DIFF
--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -47,7 +47,8 @@ export default function SettingsPage() {
           if (snap.exists()) {
             const data = snap.data();
             setFirstName(data.first_name || '');
-            setProfile((prev) => ({ ...prev, name: data.first_name || '', email: u.email || '' }));
+            const fullName = [data.first_name, data.last_name].filter(Boolean).join(' ');
+            setProfile((prev) => ({ ...prev, name: fullName, email: u.email || '' }));
           } else {
             setProfile((prev) => ({ ...prev, email: u.email || '' }));
           }
@@ -81,10 +82,16 @@ export default function SettingsPage() {
 
   const handleProfileSave = async ({ name, password }) => {
     try {
-      if (name !== profile.name) {
-        await updateDoc(doc(db, 'Users', auth.currentUser.uid), { first_name: name });
-        setProfile(prev => ({ ...prev, name }));
-        setFirstName(name);
+      const trimmed = name.trim();
+      const [first, ...rest] = trimmed.split(' ');
+      const last = rest.join(' ');
+      if (trimmed !== profile.name) {
+        await updateDoc(doc(db, 'Users', auth.currentUser.uid), {
+          first_name: first,
+          last_name: last,
+        });
+        setProfile(prev => ({ ...prev, name: trimmed }));
+        setFirstName(first);
       }
       if (password) {
         await updatePassword(auth.currentUser, password);

--- a/src/pages/TenantSettingsPage.js
+++ b/src/pages/TenantSettingsPage.js
@@ -48,7 +48,8 @@ export default function TenantSettingsPage() {
           if (snap.exists()) {
             const data = snap.data();
             setFirstName(data.first_name || '');
-            setProfile((prev) => ({ ...prev, name: data.first_name || '', email: u.email || '' }));
+            const fullName = [data.first_name, data.last_name].filter(Boolean).join(' ');
+            setProfile((prev) => ({ ...prev, name: fullName, email: u.email || '' }));
           } else {
             setProfile((prev) => ({ ...prev, email: u.email || '' }));
           }
@@ -103,10 +104,16 @@ export default function TenantSettingsPage() {
 
   const handleProfileSave = async ({ name, password }) => {
     try {
-      if (name !== profile.name) {
-        await updateDoc(doc(db, 'Users', auth.currentUser.uid), { first_name: name });
-        setProfile(prev => ({ ...prev, name }));
-        setFirstName(name);
+      const trimmed = name.trim();
+      const [first, ...rest] = trimmed.split(' ');
+      const last = rest.join(' ');
+      if (trimmed !== profile.name) {
+        await updateDoc(doc(db, 'Users', auth.currentUser.uid), {
+          first_name: first,
+          last_name: last,
+        });
+        setProfile(prev => ({ ...prev, name: trimmed }));
+        setFirstName(first);
       }
       if (password) {
         await updatePassword(auth.currentUser, password);


### PR DESCRIPTION
## Summary
- Show combined first and last names on landlord and tenant settings pages
- Split updated full names into first and last name fields when saving profiles

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689e081763748322a8fa04ac58a20659