### PR TITLE
Add conversation-based chat feature with group support

### DIFF
--- a/src/pages/ChatPage.js
+++ b/src/pages/ChatPage.js
@@ -1,27 +1,139 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { auth } from '../firebase';
+import { auth, db } from '../firebase';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  getDoc,
+  addDoc,
+  onSnapshot,
+  orderBy,
+  serverTimestamp,
+} from 'firebase/firestore';
 import MobileNav from '../components/MobileNav';
+import ChatBubble from '../components/ChatBubble';
 import { landlordNavItems } from '../constants/navItems';
 
 export default function ChatPage() {
   const [firstName, setFirstName] = useState('');
   const [user, setUser] = useState(null);
+  const [conversations, setConversations] = useState([]);
+  const [activeConv, setActiveConv] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const [properties, setProperties] = useState([]);
+  const [creating, setCreating] = useState(false);
+  const [createTarget, setCreateTarget] = useState('all');
+  const [createProp, setCreateProp] = useState('');
   const navigate = useNavigate();
 
+  // Load auth and conversations
   useEffect(() => {
-    const unsub = auth.onAuthStateChanged((u) => {
+    const unsub = auth.onAuthStateChanged(async (u) => {
       setUser(u);
-      if (u) {
-        setFirstName(u.displayName || '');
-      }
+      if (!u) return;
+      setFirstName(u.displayName || '');
+
+      const propSnap = await getDocs(
+        query(collection(db, 'Properties'), where('landlord_id', '==', u.uid))
+      );
+      const props = propSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setProperties(props);
+
+      const q = query(
+        collection(db, 'Conversations'),
+        where('participants', 'array-contains', u.uid)
+      );
+      onSnapshot(q, async (snap) => {
+        const convs = await Promise.all(
+          snap.docs.map(async (d) => {
+            const data = d.data();
+            if (data.type === 'direct') {
+              const otherUid = (data.participants || []).find((p) => p !== u.uid);
+              let name = 'Chat';
+              if (otherUid) {
+                const osnap = await getDoc(doc(db, 'Users', otherUid));
+                if (osnap.exists()) name = osnap.data().first_name || name;
+              }
+              return { id: d.id, name, ...data };
+            }
+            return { id: d.id, ...data };
+          })
+        );
+        setConversations(convs);
+      });
     });
     return () => unsub();
   }, []);
 
+  // Load messages when a conversation is selected
+  useEffect(() => {
+    if (!activeConv) return setMessages([]);
+    const mref = collection(db, 'Conversations', activeConv.id, 'Messages');
+    const q = query(mref, orderBy('createdAt'));
+    const unsub = onSnapshot(q, (snap) => {
+      const msgs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setMessages(msgs);
+    });
+    return () => unsub();
+  }, [activeConv]);
+
   const handleLogout = async () => {
     await auth.signOut();
     navigate('/signin');
+  };
+
+  const sendMessage = async (e) => {
+    e.preventDefault();
+    const t = text.trim();
+    if (!t || !user || !activeConv) return;
+    await addDoc(collection(db, 'Conversations', activeConv.id, 'Messages'), {
+      senderUid: user.uid,
+      text: t,
+      createdAt: serverTimestamp(),
+      readBy: [user.uid],
+      reactions: {},
+    });
+    setText('');
+  };
+
+  const createConversation = async (e) => {
+    e.preventDefault();
+    if (!user) return;
+    let tenantUids = [];
+    if (createTarget === 'all') {
+      properties.forEach((p) => {
+        const list = p.tenants || (p.tenant_uid ? [p.tenant_uid] : []);
+        tenantUids.push(...list);
+      });
+    } else if (createProp) {
+      const prop = properties.find((p) => p.id === createProp);
+      if (prop) {
+        tenantUids = prop.tenants || (prop.tenant_uid ? [prop.tenant_uid] : []);
+      }
+    }
+    tenantUids = Array.from(new Set(tenantUids));
+    if (tenantUids.length === 0) {
+      setCreating(false);
+      return;
+    }
+    const name =
+      createTarget === 'all'
+        ? 'All Tenants'
+        : properties.find((p) => p.id === createProp)?.address_line1 || 'Group';
+    const convRef = await addDoc(collection(db, 'Conversations'), {
+      type: 'group',
+      participants: [user.uid, ...tenantUids],
+      propertyId: createTarget === 'property' ? createProp : '',
+      name,
+    });
+    setCreating(false);
+    setCreateProp('');
+    setCreateTarget('all');
+    setActiveConv({ id: convRef.id, type: 'group', name });
   };
 
   const navItems = landlordNavItems({ active: 'chat' });
@@ -67,10 +179,114 @@ export default function ChatPage() {
           </div>
         </aside>
 
-        <div className="flex-1 p-6">
-          <div className="text-center text-gray-500 dark:text-gray-400">Chat feature coming soon.</div>
+        <div className="flex-1 p-6 flex">
+          {/* Conversation list */}
+          <div className="w-64 border-r pr-4 space-y-2">
+            <button
+              className="w-full px-3 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+              onClick={() => setCreating(true)}
+            >
+              + New Group
+            </button>
+            {conversations.map((c) => (
+              <div
+                key={c.id}
+                onClick={() => setActiveConv(c)}
+                className={`p-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                  activeConv?.id === c.id ? 'bg-gray-200 dark:bg-gray-700' : ''
+                }`}
+              >
+                {c.name || 'Conversation'}
+              </div>
+            ))}
+            {conversations.length === 0 && (
+              <div className="text-gray-500 dark:text-gray-400 text-sm">No conversations.</div>
+            )}
+          </div>
+
+          {/* Messages */}
+          <div className="flex-1 pl-4 flex flex-col">
+            <div className="flex-1 overflow-y-auto mb-4">
+              {messages.map((m) => (
+                <ChatBubble key={m.id} message={m} currentUid={user?.uid} />
+              ))}
+              {activeConv && messages.length === 0 && (
+                <div className="text-center text-gray-500 dark:text-gray-400">No messages yet.</div>
+              )}
+            </div>
+            {activeConv && (
+              <form onSubmit={sendMessage} className="flex">
+                <input
+                  type="text"
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  className="flex-1 border rounded-l p-2 dark:bg-gray-900 dark:border-gray-700"
+                  placeholder="Type a message..."
+                />
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-purple-600 text-white rounded-r hover:bg-purple-700"
+                >
+                  Send
+                </button>
+              </form>
+            )}
+            {!activeConv && (
+              <div className="text-gray-500 dark:text-gray-400 text-center mt-10">
+                Select a conversation to begin.
+              </div>
+            )}
+          </div>
         </div>
       </div>
+
+      {creating && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <form
+            onSubmit={createConversation}
+            className="bg-white dark:bg-gray-800 p-4 rounded space-y-4 w-full max-w-sm"
+          >
+            <h3 className="text-lg font-medium">New Group</h3>
+            <select
+              value={createTarget}
+              onChange={(e) => setCreateTarget(e.target.value)}
+              className="w-full border rounded p-2 dark:bg-gray-900 dark:border-gray-700"
+            >
+              <option value="all">All tenants</option>
+              <option value="property">Specific property</option>
+            </select>
+            {createTarget === 'property' && (
+              <select
+                value={createProp}
+                onChange={(e) => setCreateProp(e.target.value)}
+                className="w-full border rounded p-2 dark:bg-gray-900 dark:border-gray-700"
+              >
+                <option value="">Select property</option>
+                {properties.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.address_line1}
+                  </option>
+                ))}
+              </select>
+            )}
+            <div className="flex justify-end space-x-2">
+              <button
+                type="button"
+                className="px-4 py-2 rounded border dark:border-gray-700"
+                onClick={() => setCreating(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 bg-purple-600 text-white rounded"
+              >
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/TenantChatPage.js
+++ b/src/pages/TenantChatPage.js
@@ -1,28 +1,121 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { auth } from '../firebase';
+import { auth, db } from '../firebase';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  getDoc,
+  addDoc,
+  onSnapshot,
+  orderBy,
+  serverTimestamp,
+} from 'firebase/firestore';
 import MobileNav from '../components/MobileNav';
+import ChatBubble from '../components/ChatBubble';
 import { tenantNavItems } from '../constants/navItems';
 
 export default function TenantChatPage() {
   const [firstName, setFirstName] = useState('');
   const [user, setUser] = useState(null);
+  const [conversations, setConversations] = useState([]);
+  const [activeConv, setActiveConv] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const [landlord, setLandlord] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
-    const unsub = auth.onAuthStateChanged((u) => {
+    const unsub = auth.onAuthStateChanged(async (u) => {
       setUser(u);
-      if (u) setFirstName(u.displayName || '');
+      if (!u) return;
+      setFirstName(u.displayName || '');
+
+      // Find landlord via tenant property
+      let propSnap = await getDocs(query(collection(db, 'Properties'), where('tenants', 'array-contains', u.uid)));
+      if (propSnap.empty) {
+        propSnap = await getDocs(query(collection(db, 'Properties'), where('tenant_uid', '==', u.uid)));
+      }
+      const props = propSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      const prop = props[0];
+      if (prop) {
+        let name = 'Landlord';
+        if (prop.landlord_id) {
+          const lsnap = await getDoc(doc(db, 'Users', prop.landlord_id));
+          if (lsnap.exists()) name = lsnap.data().first_name || name;
+        }
+        setLandlord({ uid: prop.landlord_id, name });
+      }
+
+      const q = query(collection(db, 'Conversations'), where('participants', 'array-contains', u.uid));
+      onSnapshot(q, (snap) => {
+        const convs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setConversations(convs);
+      });
     });
     return () => unsub();
   }, []);
+
+  useEffect(() => {
+    if (!activeConv || !activeConv.id || activeConv.id === 'direct-temp') return setMessages([]);
+    const mref = collection(db, 'Conversations', activeConv.id, 'Messages');
+    const q = query(mref, orderBy('createdAt'));
+    const unsub = onSnapshot(q, (snap) => {
+      const msgs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setMessages(msgs);
+    });
+    return () => unsub();
+  }, [activeConv]);
 
   const handleLogout = async () => {
     await auth.signOut();
     navigate('/signin');
   };
 
+  const sendMessage = async (e) => {
+    e.preventDefault();
+    const t = text.trim();
+    if (!t || !user || !activeConv) return;
+    let convId = activeConv.id;
+    if (convId === 'direct' && landlord) {
+      const convRef = await addDoc(collection(db, 'Conversations'), {
+        type: 'direct',
+        participants: [user.uid, landlord.uid],
+      });
+      convId = convRef.id;
+      setActiveConv({ id: convId, type: 'direct', name: landlord.name });
+    }
+    await addDoc(collection(db, 'Conversations', convId, 'Messages'), {
+      senderUid: user.uid,
+      text: t,
+      createdAt: serverTimestamp(),
+      readBy: [user.uid],
+      reactions: {},
+    });
+    setText('');
+  };
+
   const navItems = tenantNavItems({ active: 'chat' });
+
+  // Prepare conversation list: landlord direct first then groups
+  const convList = () => {
+    const list = [];
+    if (landlord) {
+      const direct = conversations.find(
+        (c) => c.type === 'direct' && c.participants.includes(landlord.uid)
+      );
+      if (direct) list.push({ id: direct.id, type: 'direct', name: landlord.name });
+      else list.push({ id: 'direct', type: 'direct', name: landlord.name });
+    }
+    conversations
+      .filter((c) => c.type === 'group')
+      .forEach((c) => list.push(c));
+    return list;
+  };
+
+  const convs = convList();
 
   return (
     <div className="min-h-screen flex flex-col antialiased text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100">
@@ -65,8 +158,56 @@ export default function TenantChatPage() {
           </div>
         </aside>
 
-        <div className="flex-1 p-6">
-          <div className="text-center text-gray-500 dark:text-gray-400">Chat feature coming soon.</div>
+        <div className="flex-1 p-6 flex">
+          <div className="w-64 border-r pr-4 space-y-2">
+            {convs.map((c) => (
+              <div
+                key={c.id}
+                onClick={() => setActiveConv(c)}
+                className={`p-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                  activeConv?.id === c.id ? 'bg-gray-200 dark:bg-gray-700' : ''
+                }`}
+              >
+                {c.name || 'Conversation'}
+              </div>
+            ))}
+            {convs.length === 0 && (
+              <div className="text-gray-500 dark:text-gray-400 text-sm">No conversations.</div>
+            )}
+          </div>
+
+          <div className="flex-1 pl-4 flex flex-col">
+            <div className="flex-1 overflow-y-auto mb-4">
+              {messages.map((m) => (
+                <ChatBubble key={m.id} message={m} currentUid={user?.uid} />
+              ))}
+              {activeConv && messages.length === 0 && (
+                <div className="text-center text-gray-500 dark:text-gray-400">No messages yet.</div>
+              )}
+            </div>
+            {activeConv && (
+              <form onSubmit={sendMessage} className="flex">
+                <input
+                  type="text"
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  className="flex-1 border rounded-l p-2 dark:bg-gray-900 dark:border-gray-700"
+                  placeholder="Type a message..."
+                />
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-purple-600 text-white rounded-r hover:bg-purple-700"
+                >
+                  Send
+                </button>
+              </form>
+            )}
+            {!activeConv && (
+              <div className="text-gray-500 dark:text-gray-400 text-center mt-10">
+                Select a conversation to begin.
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Implement landlord chat page with conversation list, group creation, and messaging
- Add tenant chat page supporting direct landlord chats and group conversations
- Notify conversation participants of new messages via Cloud Function

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab652f7c8322a59c378c3ad0b3bd