### PR TITLE
Improve chat sender details and announcement sync

### DIFF
--- a/src/components/ChatBubble.js
+++ b/src/components/ChatBubble.js
@@ -1,15 +1,38 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
 
 export default function ChatBubble({ message, currentUid }) {
+  const [senderName, setSenderName] = useState(message.senderName || '');
+
+  useEffect(() => {
+    // Fetch sender name if not provided on the message object
+    if (!senderName && message.senderUid) {
+      const fetchName = async () => {
+        const snap = await getDoc(doc(db, 'Users', message.senderUid));
+        if (snap.exists()) {
+          setSenderName(snap.data().first_name || '');
+        }
+      };
+      fetchName();
+    }
+  }, [message.senderUid, senderName]);
+
   const isSender = message.senderUid === currentUid;
+
   return (
     <div className={`flex ${isSender ? 'justify-end' : 'justify-start'} mb-2`}>
-      <div
-        className={`px-3 py-2 rounded-lg max-w-xs break-words ${
-          isSender ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-900'
-        }`}
-      >
-        {message.text}
+      <div className="flex flex-col">
+        {!isSender && senderName && (
+          <span className="text-xs text-gray-500 mb-1">{senderName}</span>
+        )}
+        <div
+          className={`px-3 py-2 rounded-lg max-w-xs break-words ${
+            isSender ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-900'
+          }`}
+        >
+          {message.text}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/AnnouncementsPage.js
+++ b/src/pages/AnnouncementsPage.js
@@ -60,16 +60,22 @@ export default function AnnouncementsPage() {
       }
       setTenants(tenantData);
 
-      const annSnap = await getDocs(
-        query(collection(db, 'Announcements'), where('landlord_id', '==', u.uid), orderBy('created_at', 'desc'))
+      const annQ = query(
+        collection(db, 'Announcements'),
+        where('landlord_id', '==', u.uid),
+        orderBy('created_at', 'desc')
       );
-      const anns = annSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-      setAnnouncements(anns);
-
-      anns.forEach((a) => {
-        const rq = query(collection(db, 'AnnouncementReactions'), where('announcementId', '==', a.id));
-        onSnapshot(rq, (rsnap) => {
-          setReactions((prev) => ({ ...prev, [a.id]: rsnap.size }));
+      onSnapshot(annQ, (annSnap) => {
+        const anns = annSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setAnnouncements(anns);
+        anns.forEach((a) => {
+          const rq = query(
+            collection(db, 'AnnouncementReactions'),
+            where('announcementId', '==', a.id)
+          );
+          onSnapshot(rq, (rsnap) => {
+            setReactions((prev) => ({ ...prev, [a.id]: rsnap.size }));
+          });
         });
       });
     });
@@ -80,7 +86,7 @@ export default function AnnouncementsPage() {
     e.preventDefault();
     if (!form.message.trim() || !user) return;
 
-    const annRef = await addDoc(collection(db, 'Announcements'), {
+    await addDoc(collection(db, 'Announcements'), {
       landlord_id: user.uid,
       target: form.target,
       property_id: form.target === 'property' ? form.propertyId : '',
@@ -89,7 +95,6 @@ export default function AnnouncementsPage() {
       created_at: serverTimestamp(),
     });
 
-    setAnnouncements([{ id: annRef.id, ...form, created_at: { seconds: Date.now() / 1000 } }, ...announcements]);
     setForm({ target: 'all', propertyId: '', tenantUid: '', message: '' });
   };
 

--- a/src/pages/ChatPage.js
+++ b/src/pages/ChatPage.js
@@ -110,6 +110,7 @@ export default function ChatPage() {
     if (!t || !user || !activeConv) return;
     await addDoc(collection(db, 'Conversations', activeConv.id, 'Messages'), {
       senderUid: user.uid,
+      senderName: firstName,
       text: t,
       createdAt: serverTimestamp(),
       readBy: [user.uid],

--- a/src/pages/TenantAnnouncementsPage.js
+++ b/src/pages/TenantAnnouncementsPage.js
@@ -47,23 +47,29 @@ export default function TenantAnnouncementsPage() {
       const prop = { id: propDoc.id, ...propDoc.data() };
       setProperty(prop);
 
-      const annSnap = await getDocs(
-        query(collection(db, 'Announcements'), where('landlord_id', '==', prop.landlord_id), orderBy('created_at', 'desc'))
+      const annQ = query(
+        collection(db, 'Announcements'),
+        where('landlord_id', '==', prop.landlord_id),
+        orderBy('created_at', 'desc')
       );
-      const data = annSnap.docs
-        .map((d) => ({ id: d.id, ...d.data() }))
-        .filter(
-          (a) =>
-            a.target === 'all' ||
-            (a.target === 'property' && a.property_id === prop.id) ||
-            (a.target === 'tenant' && a.tenant_uid === u.uid)
-        );
-      setAnnouncements(data);
-
-      data.forEach((a) => {
-        const rq = query(collection(db, 'AnnouncementReactions'), where('announcementId', '==', a.id));
-        onSnapshot(rq, (rsnap) => {
-          setReactions((prev) => ({ ...prev, [a.id]: rsnap.size }));
+      onSnapshot(annQ, (annSnap) => {
+        const data = annSnap.docs
+          .map((d) => ({ id: d.id, ...d.data() }))
+          .filter(
+            (a) =>
+              a.target === 'all' ||
+              (a.target === 'property' && a.property_id === prop.id) ||
+              (a.target === 'tenant' && a.tenant_uid === u.uid)
+          );
+        setAnnouncements(data);
+        data.forEach((a) => {
+          const rq = query(
+            collection(db, 'AnnouncementReactions'),
+            where('announcementId', '==', a.id)
+          );
+          onSnapshot(rq, (rsnap) => {
+            setReactions((prev) => ({ ...prev, [a.id]: rsnap.size }));
+          });
         });
       });
     });

--- a/src/pages/TenantChatPage.js
+++ b/src/pages/TenantChatPage.js
@@ -90,6 +90,7 @@ export default function TenantChatPage() {
     }
     await addDoc(collection(db, 'Conversations', convId, 'Messages'), {
       senderUid: user.uid,
+      senderName: firstName,
       text: t,
       createdAt: serverTimestamp(),
       readBy: [user.uid],


### PR DESCRIPTION
## Summary
- Show sender names above chat messages
- Include sender name when sending messages
- Use realtime listeners for landlord and tenant announcements

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a4be07f65c832291c77a0b7237d9ec