### PR TITLE
Fix announcement retrieval without Firestore index

### DIFF
--- a/src/pages/AnnouncementsPage.js
+++ b/src/pages/AnnouncementsPage.js
@@ -12,7 +12,6 @@ import {
   setDoc,
   serverTimestamp,
   onSnapshot,
-  orderBy,
 } from 'firebase/firestore';
 import MobileNav from '../components/MobileNav';
 import AlertModal from '../components/AlertModal';
@@ -62,11 +61,12 @@ export default function AnnouncementsPage() {
 
       const annQ = query(
         collection(db, 'Announcements'),
-        where('landlord_id', '==', u.uid),
-        orderBy('created_at', 'desc')
+        where('landlord_id', '==', u.uid)
       );
       onSnapshot(annQ, (annSnap) => {
-        const anns = annSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        const anns = annSnap.docs
+          .map((d) => ({ id: d.id, ...d.data() }))
+          .sort((a, b) => (b.created_at?.seconds || 0) - (a.created_at?.seconds || 0));
         setAnnouncements(anns);
         anns.forEach((a) => {
           const rq = query(

--- a/src/pages/TenantAnnouncementsPage.js
+++ b/src/pages/TenantAnnouncementsPage.js
@@ -11,7 +11,6 @@ import {
   onSnapshot,
   setDoc,
   serverTimestamp,
-  orderBy,
 } from 'firebase/firestore';
 import MobileNav from '../components/MobileNav';
 import AlertModal from '../components/AlertModal';
@@ -49,12 +48,12 @@ export default function TenantAnnouncementsPage() {
 
       const annQ = query(
         collection(db, 'Announcements'),
-        where('landlord_id', '==', prop.landlord_id),
-        orderBy('created_at', 'desc')
+        where('landlord_id', '==', prop.landlord_id)
       );
       onSnapshot(annQ, (annSnap) => {
         const data = annSnap.docs
           .map((d) => ({ id: d.id, ...d.data() }))
+          .sort((a, b) => (b.created_at?.seconds || 0) - (a.created_at?.seconds || 0))
           .filter(
             (a) =>
               a.target === 'all' ||


### PR DESCRIPTION
## Summary
- Remove Firestore `orderBy` from announcements queries
- Sort announcement results locally by `created_at`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9ce55c483229f30f76dc12e8cf1