### PR TITLE
Ensure dashboard sidebars show active link

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export default function Sidebar({ navItems = [], firstName = 'User', user }) {
+  const activeRef = useRef(null);
+
+  useEffect(() => {
+    if (activeRef.current) {
+      activeRef.current.scrollIntoView({ block: 'nearest' });
+    }
+  }, [navItems]);
+
   return (
-    <aside className="hidden lg:flex flex-col w-64 bg-white dark:bg-gray-800 shadow-lg min-h-[calc(100vh-5rem)] justify-between">
+    <aside className="hidden lg:flex flex-col w-64 bg-white dark:bg-gray-800 shadow-lg min-h-[calc(100vh-5rem)] justify-between overflow-y-auto">
       <nav className="px-4 space-y-2 mt-4">
         {navItems.map((item) => (
           <a
             key={item.href}
+            ref={item.active ? activeRef : null}
             href={item.href}
             className={`flex items-center px-4 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 ${
               item.active ? 'bg-purple-100 text-purple-700 dark:bg-gray-700 dark:text-purple-200' : ''
@@ -31,4 +40,3 @@ export default function Sidebar({ navItems = [], firstName = 'User', user }) {
     </aside>
   );
 }
-


### PR DESCRIPTION
## Summary
- auto-scroll sidebar so active navigation item is visible

## Testing
- `CI=true npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68a5e0c73ddc8322b1c4a7c421d204ea