### PR TITLE
Fix sidebar hidden under header on dashboard and properties pages

### DIFF
--- a/src/pages/LandlordDashboard.js
+++ b/src/pages/LandlordDashboard.js
@@ -237,12 +237,12 @@ export default function LandlordDashboard() {
         </div>
       </header>
 
-      <div className="flex flex-1">
+      <div className="flex flex-1 pt-20 min-h-[calc(100vh-5rem)]">
         {/* Sidebar (Desktop) */}
         <Sidebar navItems={navItems} firstName={firstName} user={user} />
         {/* Main Content */}
         <div className="flex-1 flex flex-col">
-          <main className="flex-1 p-6 overflow-y-auto space-y-8 pt-24">
+          <main className="flex-1 p-6 overflow-y-auto space-y-8">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               {/* Rent Collected */}
               <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">

--- a/src/pages/PropertiesPage.js
+++ b/src/pages/PropertiesPage.js
@@ -294,7 +294,7 @@ export default function PropertiesPage() {
   };
 
   return (
-    <div className="flex h-screen overflow-hidden bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 antialiased">
+    <div className="flex pt-20 min-h-[calc(100vh-5rem)] overflow-hidden bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 antialiased">
       {/* Sidebar */}
         <Sidebar navItems={navItems} firstName={firstName} user={user} />
 
@@ -330,7 +330,7 @@ export default function PropertiesPage() {
         </header>
 
         {/* Properties Table */}
-        <main className="pt-24 p-6 overflow-auto mx-6">
+        <main className="p-6 overflow-auto mx-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             {properties.map((prop) => (
               <div key={prop.id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg overflow-hidden">

--- a/src/pages/TenantDashboard.js
+++ b/src/pages/TenantDashboard.js
@@ -330,11 +330,11 @@ export default function TenantDashboard() {
       <div className="min-h-screen flex flex-col antialiased text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100">
         <Header />
 
-        <div className="flex flex-1">
+        <div className="flex flex-1 pt-20 min-h-[calc(100vh-5rem)]">
         <Sidebar navItems={navItems} firstName={userFirstName} user={{ email: userEmail }} />
 
           <div className="flex-1 flex flex-col">
-            <main className="flex-1 p-6 overflow-y-auto space-y-8 pt-24">
+            <main className="flex-1 p-6 overflow-y-auto space-y-8">
               {/* Render main dashboard (Active tenant) */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">


### PR DESCRIPTION
## Summary
- shift dashboard and properties layouts down so sidebars start below fixed header
- remove redundant top padding from page content to keep spacing consistent

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea42b2948322b7c6342678c7f53b