### PR TITLE
Fix signed lease saving after Dropbox Sign

### DIFF
--- a/src/pages/TenantDashboard.js
+++ b/src/pages/TenantDashboard.js
@@ -185,11 +185,11 @@ export default function TenantDashboard() {
 
       try {
         const client = new HelloSign({ clientId: HELLOSIGN_CLIENT_ID });
-        const handleSign = async () => {
+        const handleFinish = async () => {
           await saveSignedAgreement();
-          client.off('sign', handleSign);
+          client.off('finish', handleFinish);
         };
-        client.on('sign', handleSign);
+        client.on('finish', handleFinish);
         client.open(signUrl, { skipDomainVerification: true });
       } catch (e) {
         console.error('Failed to launch HelloSign', e);


### PR DESCRIPTION
## Summary
- save signed agreements after Dropbox Sign's `finish` event to ensure the PDF is uploaded

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a681d2f2548322b44a48b21fbf14ea